### PR TITLE
fix(map-search): make listing status filter actually fetch matching i…

### DIFF
--- a/backend/app/schemas/property.py
+++ b/backend/app/schemas/property.py
@@ -1055,6 +1055,14 @@ class MapSearchRequest(BaseModel):
     max_price: float | None = None
     bedrooms: int | None = None
     bathrooms: float | None = None
+    listing_statuses: list[str] | None = Field(
+        default=None,
+        description=(
+            "Canonical listing status filter. Values: 'active', 'pending', "
+            "'foreclosure', 'pre-foreclosure', 'auction'. None or empty list "
+            "means active-only (current default behavior)."
+        ),
+    )
     limit: int = Field(default=500, le=500)
     offset: int = 0
 

--- a/backend/app/services/map_search_service.py
+++ b/backend/app/services/map_search_service.py
@@ -25,6 +25,52 @@ logger = logging.getLogger(__name__)
 
 MAP_CACHE_TTL = 600  # 10 minutes
 
+# ─── Listing status canonicalization ─────────────────────────────────────
+# Mirrors frontend/src/lib/dealSignal.ts :: STATUS_MAP. Keep in sync; if these
+# drift the user-visible filter and the server-side filter will disagree.
+
+CANONICAL_STATUSES: set[str] = {
+    "active",
+    "pending",
+    "foreclosure",
+    "pre-foreclosure",
+    "auction",
+}
+
+_STATUS_MAP: dict[str, str] = {
+    # Zillow homeStatus values
+    "for_sale": "active",
+    "for_rent": "active",
+    "pending": "pending",
+    "pre_foreclosure": "pre-foreclosure",
+    "pre-foreclosure": "pre-foreclosure",
+    "preforeclosure": "pre-foreclosure",
+    # RentCast status values
+    "active": "active",
+    # Distressed / special
+    "foreclosure": "foreclosure",
+    "foreclosed": "foreclosure",
+    "auction": "auction",
+    "bank owned": "foreclosure",
+    "bank_owned": "foreclosure",
+    "bankowned": "foreclosure",
+    "reo": "foreclosure",
+    "short sale": "pre-foreclosure",
+    "short_sale": "pre-foreclosure",
+    "shortsale": "pre-foreclosure",
+    # Motivation indicators
+    "contingent": "pending",
+    "under contract": "pending",
+    "under_contract": "pending",
+}
+
+
+def normalize_listing_status(raw: str | None) -> str | None:
+    """Map a raw provider status to a canonical status, or None if unknown."""
+    if not raw:
+        return None
+    return _STATUS_MAP.get(raw.lower().strip())
+
 
 def _round_coord(val: float, precision: int = 3) -> float:
     """Round a coordinate for cache key stability (~111 m at the equator)."""
@@ -45,6 +91,7 @@ def _build_cache_key(req: MapSearchRequest) -> str:
             "maxp": req.max_price,
             "bed": req.bedrooms,
             "bath": req.bathrooms,
+            "ls": sorted(req.listing_statuses) if req.listing_statuses else None,
             "lim": req.limit,
             "off": req.offset,
         },
@@ -166,6 +213,14 @@ class MapSearchService:
         )
         sub_radius = min(cell_diag / 2, 100.0) if grid_size > 1 else min(radius, 25.0)
 
+        # Resolve which canonical statuses the caller wants. None/empty
+        # preserves today's behavior (active-only). Unknown values are
+        # silently dropped so the API stays forgiving for clients on older
+        # builds.
+        requested_statuses = {
+            s for s in (req.listing_statuses or ["active"]) if s in CANONICAL_STATUSES
+        } or {"active"}
+
         listings: list[MapListing] = []
         seen_addresses: set[str] = set()
         raw_source_totals: int = 0
@@ -175,30 +230,43 @@ class MapSearchService:
 
         for pt_lat, pt_lng in query_points:
             if req.listing_type in ("sale", "both"):
-                tasks.append(
-                    asyncio.create_task(
-                        self._fetch_rentcast(req, "sale", pt_lat, pt_lng),
-                    )
-                )
-                if self.zillow:
+                # RentCast only serves active sale listings. If the caller
+                # wants only distressed inventory, skip RentCast entirely
+                # to save API quota.
+                if "active" in requested_statuses or "pending" in requested_statuses:
                     tasks.append(
                         asyncio.create_task(
-                            self._fetch_zillow(pt_lat, pt_lng, sub_radius, "forSale", req),
+                            self._fetch_rentcast(req, "sale", pt_lat, pt_lng),
                         )
                     )
+                if self.zillow:
+                    for distress_flag in self._zillow_sale_flag_set(requested_statuses):
+                        tasks.append(
+                            asyncio.create_task(
+                                self._fetch_zillow(
+                                    pt_lat, pt_lng, sub_radius, "forSale", req, distress_flag
+                                ),
+                            )
+                        )
 
             if req.listing_type in ("rental", "both"):
-                tasks.append(
-                    asyncio.create_task(
-                        self._fetch_rentcast(req, "rental", pt_lat, pt_lng),
-                    )
-                )
-                if self.zillow:
+                # Distressed/pending semantics don't apply to rentals;
+                # only fetch when the caller wants active inventory (or no
+                # explicit status filter, which defaults to active).
+                if "active" in requested_statuses:
                     tasks.append(
                         asyncio.create_task(
-                            self._fetch_zillow(pt_lat, pt_lng, sub_radius, "forRent", req),
+                            self._fetch_rentcast(req, "rental", pt_lat, pt_lng),
                         )
                     )
+                    if self.zillow:
+                        tasks.append(
+                            asyncio.create_task(
+                                self._fetch_zillow(
+                                    pt_lat, pt_lng, sub_radius, "forRent", req, None
+                                ),
+                            )
+                        )
 
         results = await asyncio.gather(*tasks, return_exceptions=True)
 
@@ -225,6 +293,16 @@ class MapSearchService:
         if req.bathrooms is not None:
             listings = [item for item in listings if item.bathrooms is not None and item.bathrooms >= req.bathrooms]
 
+        # Authoritative status filter — guarantees the response only
+        # contains the statuses the caller asked for, regardless of how
+        # generous each upstream provider was. Unrecognized statuses are
+        # also dropped here.
+        listings = [
+            item
+            for item in listings
+            if normalize_listing_status(item.listing_status) in requested_statuses
+        ]
+
         # Estimate total: if every sub-query returned its limit, there are
         # likely more listings than we fetched. Extrapolate conservatively.
         estimated_total: int | None = None
@@ -236,8 +314,9 @@ class MapSearchService:
                 estimated_total = int(avg_per_query * area_multiplier * 1.5)
 
         logger.info(
-            "Map search returned %d listings from %d grid points (radius=%.1fmi, grid=%dx%d)",
+            "Map search returned %d listings (statuses=%s, %d grid points, radius=%.1fmi, grid=%dx%d)",
             len(listings),
+            sorted(requested_statuses),
             len(query_points),
             radius,
             grid_size,
@@ -253,6 +332,34 @@ class MapSearchService:
 
         await cache.set(cache_key, response.model_dump(mode="json"), ttl_seconds=MAP_CACHE_TTL)
         return response
+
+    @staticmethod
+    def _zillow_sale_flag_set(requested_statuses: set[str]) -> list[str | None]:
+        """Return the set of Zillow distress flags to issue queries for.
+
+        Each entry produces one Zillow `search-by-coordinates` call:
+        - ``None`` → vanilla forSale query (covers active + most pending)
+        - ``"isForeclosure"`` → forSale + isForeclosure=true
+        - ``"isPreforeclosure"`` → forSale + isPreforeclosure=true
+        - ``"isAuction"`` → forSale + isAuction=true
+
+        We deliberately keep distressed queries separate from the base
+        forSale query so a single mis-named AXESSO flag only breaks one
+        slice of results, not the whole map. The exact AXESSO param names
+        are inferred from Zillow's data model and the existing
+        ``isSingleFamily`` / ``isCondo`` convention used elsewhere in this
+        client; verify against live results post-deploy.
+        """
+        flags: list[str | None] = []
+        if "active" in requested_statuses or "pending" in requested_statuses:
+            flags.append(None)
+        if "foreclosure" in requested_statuses:
+            flags.append("isForeclosure")
+        if "pre-foreclosure" in requested_statuses:
+            flags.append("isPreforeclosure")
+        if "auction" in requested_statuses:
+            flags.append("isAuction")
+        return flags
 
     # ─── RentCast ───────────────────────────────────
 
@@ -302,6 +409,7 @@ class MapSearchService:
         radius_miles: float,
         status: str,
         req: MapSearchRequest,
+        distress_flag: str | None = None,
     ) -> list[MapListing]:
         if not self.zillow:
             return []
@@ -318,6 +426,9 @@ class MapSearchService:
                 elif "multi" in pt:
                     kwargs["isMultiFamily"] = True
 
+            if distress_flag:
+                kwargs[distress_flag] = True
+
             resp = await self.zillow.search_by_coordinates(
                 lat=center_lat,
                 lng=center_lng,
@@ -326,8 +437,10 @@ class MapSearchService:
                 **kwargs,
             )
 
+            label = f"{status}+{distress_flag}" if distress_flag else status
+
             if not resp.success or not resp.data:
-                logger.info("Zillow %s returned no data", status)
+                logger.info("Zillow %s returned no data", label)
                 return []
 
             raw_props = resp.data.get("props") or resp.data.get("searchResults") or resp.data.get("results") or []
@@ -338,10 +451,13 @@ class MapSearchService:
                         break
 
             results = [self._normalize_zillow_listing(item) for item in raw_props if self._zillow_has_coords(item)]
-            logger.info("Zillow %s: %d listings", status, len(results))
+            logger.info("Zillow %s: %d listings", label, len(results))
             return results
         except Exception:
-            logger.exception("Zillow %s listing fetch failed", status)
+            logger.exception(
+                "Zillow %s listing fetch failed",
+                f"{status}+{distress_flag}" if distress_flag else status,
+            )
             return []
 
     # ─── Normalization helpers ─────────────────────
@@ -374,6 +490,15 @@ class MapSearchService:
                 parts.append(f"{state} {zipcode}".strip())
             address = ", ".join(p for p in parts if p)
 
+        # Prefer RentCast's listingType when it surfaces distress
+        # ("Foreclosure" / "Short Sale") so the canonical status filter
+        # routes the listing correctly. Otherwise fall back to status
+        # ("Active" / "Inactive").
+        listing_type = (item.get("listingType") or "").strip()
+        raw_status = item.get("status")
+        if listing_type and listing_type.lower() in {"foreclosure", "short sale"}:
+            raw_status = listing_type
+
         return MapListing(
             id=item.get("id") or f"rc-{item.get('latitude')}-{item.get('longitude')}",
             address=address,
@@ -387,7 +512,7 @@ class MapSearchService:
             bathrooms=item.get("bathrooms"),
             sqft=item.get("squareFootage"),
             property_type=item.get("propertyType"),
-            listing_status=item.get("status"),
+            listing_status=raw_status,
             photo_url=item.get("photoUrl") or item.get("imgSrc"),
             source="rentcast",
             days_on_market=item.get("daysOnMarket"),
@@ -433,6 +558,13 @@ class MapSearchService:
         if not photo_url and isinstance(item.get("miniCardPhotos"), list) and item["miniCardPhotos"]:
             photo_url = item["miniCardPhotos"][0].get("url")
 
+        # Derive an effective status that includes distress signals.
+        # Zillow returns homeStatus="FOR_SALE" even for foreclosure /
+        # auction listings — the distinction lives in listingSubType
+        # and foreclosureTypes. Without this, distressed listings would
+        # canonicalize to "active" and get dropped by the status filter.
+        listing_status = MapSearchService._derive_zillow_status(item)
+
         return MapListing(
             id=str(item.get("zpid") or item.get("id") or f"zl-{lat}-{lng}"),
             address=address,
@@ -446,12 +578,39 @@ class MapSearchService:
             bathrooms=item.get("bathrooms") or item.get("baths"),
             sqft=item.get("livingArea") or item.get("squareFootage") or item.get("area"),
             property_type=item.get("propertyType") or item.get("homeType"),
-            listing_status=item.get("homeStatus") or item.get("listingStatus"),
+            listing_status=listing_status,
             photo_url=photo_url,
             source="zillow",
             days_on_market=item.get("daysOnZillow"),
             year_built=item.get("yearBuilt"),
         )
+
+    @staticmethod
+    def _derive_zillow_status(item: dict) -> str | None:
+        """Pick the most informative status label from a Zillow record.
+
+        Distress flags win over generic homeStatus. Order matters:
+        pre-foreclosure beats foreclosure beats auction beats bank-owned
+        beats whatever homeStatus says — because the more specific signal
+        is the one investors actually filter on.
+        """
+        sub = item.get("listingSubType") or {}
+        fore_types = item.get("foreclosureTypes") or {}
+
+        if fore_types.get("isPreforeclosure") or fore_types.get("isPreForeclosure"):
+            return "Pre-Foreclosure"
+        if (
+            fore_types.get("isAnyForeclosure")
+            or fore_types.get("wasForeclosed")
+            or sub.get("isForeclosure")
+        ):
+            return "Foreclosure"
+        if sub.get("isForAuction") or fore_types.get("wasNonRetailAuction"):
+            return "Auction"
+        if sub.get("isBankOwned") or fore_types.get("isBankOwned"):
+            return "Foreclosure"
+
+        return item.get("homeStatus") or item.get("listingStatus")
 
 
 map_search_service = MapSearchService()

--- a/frontend/src/components/map-search/MapSearchView.tsx
+++ b/frontend/src/components/map-search/MapSearchView.tsx
@@ -851,6 +851,8 @@ export function MapSearchView() {
         selectedId={selectedListing?.id ?? null}
         onSelectListing={handleCardSelect}
         isLoading={isLoading}
+        activeStatuses={filters.listing_statuses}
+        onResetStatuses={() => updateFilters({ listing_statuses: [] })}
       />
     </div>
   )

--- a/frontend/src/components/map-search/PropertyCardList.tsx
+++ b/frontend/src/components/map-search/PropertyCardList.tsx
@@ -20,6 +20,16 @@ interface PropertyCardListProps {
   selectedId: string | null
   onSelectListing: (listing: MapListing) => void
   isLoading: boolean
+  activeStatuses?: string[]
+  onResetStatuses?: () => void
+}
+
+const STATUS_LABELS: Record<string, string> = {
+  active: 'Active',
+  pending: 'Pending',
+  foreclosure: 'Foreclosure',
+  'pre-foreclosure': 'Pre-Foreclosure',
+  auction: 'Auction',
 }
 
 function formatPrice(price: number | null): string {
@@ -228,6 +238,8 @@ export function PropertyCardList({
   selectedId,
   onSelectListing,
   isLoading,
+  activeStatuses,
+  onResetStatuses,
 }: PropertyCardListProps) {
   const cardRefs = useRef<Map<string, HTMLDivElement>>(new globalThis.Map())
 
@@ -264,15 +276,42 @@ export function PropertyCardList({
   }
 
   if (listings.length === 0) {
+    const hasStatusFilter = (activeStatuses?.length ?? 0) > 0
+    const onlyDistressed =
+      hasStatusFilter && (activeStatuses ?? []).every((s) => s !== 'active')
+    const statusList = (activeStatuses ?? [])
+      .map((s) => STATUS_LABELS[s] ?? s)
+      .join(', ')
+
     return (
       <div className="flex items-center justify-center h-full p-8">
-        <div className="text-center space-y-1">
+        <div className="text-center space-y-2 max-w-xs">
           <p className="text-sm font-medium" style={{ color: 'var(--text-heading)' }}>
             No properties found
           </p>
-          <p className="text-xs" style={{ color: 'var(--text-secondary)' }}>
-            Try adjusting filters or zooming to a different area
-          </p>
+          {hasStatusFilter ? (
+            <>
+              <p className="text-xs" style={{ color: 'var(--text-secondary)' }}>
+                {onlyDistressed
+                  ? `No ${statusList} listings in this area right now. Distressed inventory is sparse — try a wider view or a different market.`
+                  : `No ${statusList} listings in this area. Try widening filters or panning the map.`}
+              </p>
+              {onResetStatuses && (
+                <button
+                  type="button"
+                  onClick={onResetStatuses}
+                  className="text-xs font-semibold underline-offset-2 hover:underline"
+                  style={{ color: 'var(--accent-sky)' }}
+                >
+                  Reset to Active listings
+                </button>
+              )}
+            </>
+          ) : (
+            <p className="text-xs" style={{ color: 'var(--text-secondary)' }}>
+              Try adjusting filters or zooming to a different area
+            </p>
+          )}
         </div>
       </div>
     )

--- a/frontend/src/hooks/useMapSearch.ts
+++ b/frontend/src/hooks/useMapSearch.ts
@@ -67,6 +67,8 @@ export function useMapSearch() {
         max_price: activeFilters.max_price,
         bedrooms: activeFilters.bedrooms,
         bathrooms: activeFilters.bathrooms,
+        listing_statuses:
+          activeFilters.listing_statuses.length > 0 ? activeFilters.listing_statuses : undefined,
         limit: 500,
       }
 
@@ -134,7 +136,8 @@ export function useMapSearch() {
         'min_price' in next ||
         'max_price' in next ||
         'bedrooms' in next ||
-        'bathrooms' in next
+        'bathrooms' in next ||
+        'listing_statuses' in next
       )
 
       setFilters((prev) => {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -236,6 +236,7 @@ export interface MapSearchRequest {
   max_price?: number
   bedrooms?: number
   bathrooms?: number
+  listing_statuses?: string[]
   limit?: number
   offset?: number
 }


### PR DESCRIPTION
…nventory

Distressed and pending status pills returned zero results because (1) the backend hardcoded `status=Active` / `status=forSale` against RentCast and Zillow regardless of what the user toggled, (2) `listing_statuses` was silently dropped at the request boundary since it wasn't on the schema, and (3) the frontend treated status changes as a client-only filter and never refetched. The result was a UI promise the data pipeline couldn't keep — five pills with one functional outcome.

Backend
- Add `listing_statuses` to `MapSearchRequest` (None/empty preserves active-only default for older clients).
- Add a canonical status map mirroring `frontend/src/lib/dealSignal.ts` so RentCast `Foreclosure`/`Short Sale` and Zillow `FOR_SALE` + `listingSubType.isForeclosure` both route to the right bucket.
- Status-aware dispatch: only issue Zillow distress queries when explicitly requested; skip RentCast entirely when the caller wants distressed-only inventory. Costs scale with intent, not with every pan/zoom.
- Apply an authoritative canonical status filter on the merged result set so the response never includes statuses the caller didn't ask for, even on cache hits or generous upstream payloads.
- Include `listing_statuses` in the cache key so distressed and active searches cache independently.
- Enhance the Zillow normalizer to derive an effective status from `listingSubType` and `foreclosureTypes`, so a foreclosure listing reported as `homeStatus=FOR_SALE` survives the canonical filter.
- Fold RentCast `listingType` ("Foreclosure" / "Short Sale") into the listing status the same way.

Frontend
- Add `listing_statuses` to `MapSearchRequest` and include it in the outbound payload (omitted when empty so today's behavior is preserved for unaffected sessions).
- Add `listing_statuses` to the `needsRefetch` check so toggling a status pill triggers a fresh server fetch instead of filtering the already-narrowed cache.
- Status-aware empty state in `PropertyCardList` with a one-tap "Reset to Active listings" affordance — distressed inventory is genuinely sparse in many markets, and the previous generic message read as a bug.

No new tests because there's no existing coverage for `map_search_service`; manual smoke test verified the canonical map, dispatch flag generation, and Zillow distress derivation against representative payloads.

Made-with: Cursor

## Summary

<!-- 1-3 bullet points describing the change -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update

## Cross-Platform Impact

<!-- REQUIRED: Check all that apply. Frontend ↔ Mobile parity is critical. -->

- [ ] **Frontend only** — No mobile impact
- [ ] **Mobile only** — No frontend impact
- [ ] **Both platforms affected** — Changes require corresponding updates to maintain parity
- [ ] **Shared types/constants affected** — Update `shared/` package and both consumers
- [ ] **Backend API change** — Frontend AND mobile may need updates

### If both platforms are affected:

- [ ] I have updated the corresponding code in the other platform
- [ ] I have verified type alignment between platforms
- [ ] I have run `scripts/parity-check.sh` and it passes

### If this is a backend API change:

- [ ] Frontend API client has been updated
- [ ] Mobile API client has been updated
- [ ] Shared types have been updated (if applicable)

## Areas Affected

<!-- Check which systems this change touches -->

- [ ] Financial calculations (mortgage, NOI, cap rate, CoC, DSCR, IRR)
- [ ] Deal scoring / grading
- [ ] Strategy worksheets
- [ ] Deal Maker
- [ ] IQ Target / Verdict
- [ ] Design tokens / theme
- [ ] Authentication / user profile
- [ ] API services / data flow
- [ ] State management (Zustand stores)
- [ ] Navigation / routing

## Test Plan

<!-- How did you verify this change works correctly? -->

- [ ] Manual testing on affected platform(s)
- [ ] Cross-platform test fixtures pass (`shared/test-fixtures/`)
- [ ] Parity check passes (`scripts/parity-check.sh`)
- [ ] No linter errors introduced

### If touching container backgrounds or theme tokens:

- [ ] `npm run theme:check:strict` passes (enforced in CI)
- [ ] Dark mode containers render pure black (not washed-out navy)
- [ ] Light mode containers render correctly
- [ ] Page shells use `var(--surface-base)`, cards use `var(--surface-card)`

## Screenshots / Recordings

<!-- If this change affects UI, include before/after screenshots -->

## Notes for Reviewers

<!-- Any context that would help review this PR -->
