### PR TITLE
feat(insurance): split estimate into market-baseline + risk-adjusted

### DIFF
--- a/backend/app/schemas/property.py
+++ b/backend/app/schemas/property.py
@@ -350,7 +350,8 @@ class MarketData(BaseModel):
     market_health_score: int | None = None
     market_strength: str | None = None
     property_taxes_annual: float | None = None
-    insurance_annual: float | None = None
+    insurance_annual: float | None = None  # Market baseline (1% rule-of-thumb) — feeds Deal Gap
+    insurance_annual_risk_adjusted: float | None = None  # County ACS + state calibration; UI transparency layer
     hoa_fees_monthly: float | None = None
     # Mortgage rate data for frontend calculations
     mortgage_rate_arm5: float | None = None
@@ -511,6 +512,7 @@ class OperatingAssumptions(BaseModel):
     capex_pct: float = Field(default_factory=lambda: OPERATING.capex_pct)
     insurance_pct: float = Field(default_factory=lambda: OPERATING.insurance_pct)
     insurance_annual: float | None = None  # Calculated from insurance_pct if not provided
+    insurance_annual_risk_adjusted: float | None = None  # County+state methodology; UI transparency layer
     utilities_monthly: float = Field(default_factory=lambda: OPERATING.utilities_monthly)
     landscaping_annual: float = Field(default_factory=lambda: OPERATING.landscaping_annual)
     pest_control_annual: float = Field(default_factory=lambda: OPERATING.pest_control_annual)
@@ -530,6 +532,7 @@ class STRAssumptions(BaseModel):
     furniture_setup_cost: float = Field(default_factory=lambda: STR.furniture_setup_cost)
     str_insurance_pct: float = Field(default_factory=lambda: STR.str_insurance_pct)
     str_insurance_annual: float | None = None  # Calculated from str_insurance_pct if not provided
+    str_insurance_annual_risk_adjusted: float | None = None  # County+state methodology; UI transparency layer
     buy_discount_pct: float = Field(default_factory=lambda: BRRRR.buy_discount_pct)
 
 

--- a/backend/app/services/property_service.py
+++ b/backend/app/services/property_service.py
@@ -1146,7 +1146,7 @@ class PropertyService:
             value fed into operating expenses for the headline Deal Gap, so
             our presentation matches market convention. Falls back to $1,500
             when no price data is available.
-        risk_adjusted: county-level ACS landlord ratio × state calibration
+        risk_adjusted: county-level ACS landlord ratio x state calibration
             multiplier (preferred), or state ZIP-based rate (fallback).
             Surfaced in the UI as a transparency layer next to the baseline.
             Returns None when neither county nor ZIP data resolves.

--- a/backend/app/services/property_service.py
+++ b/backend/app/services/property_service.py
@@ -596,6 +596,10 @@ class PropertyService:
         if address_obj.longitude is None:
             address_obj.longitude = normalized.get("longitude")
 
+        # Insurance: baseline (1% rule-of-thumb) feeds the headline Deal Gap;
+        # risk_adjusted (county+state methodology) is surfaced as a transparency layer.
+        insurance_baseline, insurance_risk_adjusted = self._estimate_insurance(normalized)
+
         # Build response
         response = PropertyResponse(
             property_id=property_id,
@@ -706,7 +710,8 @@ class PropertyService:
             ),
             market=MarketData(
                 property_taxes_annual=normalized.get("property_taxes_annual") or self._estimate_taxes(normalized),
-                insurance_annual=self._estimate_insurance(normalized),
+                insurance_annual=insurance_baseline,
+                insurance_annual_risk_adjusted=insurance_risk_adjusted,
                 hoa_fees_monthly=normalized.get("hoa_fees_monthly", 0),
                 # Mortgage rates for frontend
                 mortgage_rate_arm5=normalized.get("mortgage_rate_arm5"),
@@ -1133,11 +1138,18 @@ class PropertyService:
             return avm * 0.012
         return 4500  # Default fallback
 
-    def _estimate_insurance(self, data: dict) -> float:
-        """Estimate annual insurance.
+    def _estimate_insurance(self, data: dict) -> tuple[float, float | None]:
+        """Estimate annual insurance — returns (baseline, risk_adjusted).
 
-        Primary: county-level landlord ratio (ACS) x state market calibration.
-        Fallback: state insurance_rate from :func:`get_market_adjustments` (ZIP).
+        baseline: 1% of market price (industry rule-of-thumb used by
+            BiggerPockets, Mashvisor, Zillow-style calculators). This is the
+            value fed into operating expenses for the headline Deal Gap, so
+            our presentation matches market convention. Falls back to $1,500
+            when no price data is available.
+        risk_adjusted: county-level ACS landlord ratio × state calibration
+            multiplier (preferred), or state ZIP-based rate (fallback).
+            Surfaced in the UI as a transparency layer next to the baseline.
+            Returns None when neither county nor ZIP data resolves.
         """
         from app.services import insurance_lookup
         from app.services.assumptions_service import get_market_adjustments
@@ -1149,7 +1161,9 @@ class PropertyService:
             or data.get("list_price")
         )
         if not market_price:
-            return 1500  # safe fallback when no price data available
+            return 1500.0, None
+
+        baseline = round(float(market_price) * 0.01, 2)
 
         county_annual = insurance_lookup.estimate_landlord_insurance_annual(
             float(market_price),
@@ -1157,12 +1171,15 @@ class PropertyService:
             data.get("county"),
         )
         if county_annual is not None:
-            return float(county_annual)
+            return baseline, float(county_annual)
 
         zip_code = data.get("zip_code", "")
         adjustments = get_market_adjustments(zip_code)
-        insurance_rate = adjustments.get("insurance_rate", 0.01)
-        return round(market_price * insurance_rate, 2)
+        insurance_rate = adjustments.get("insurance_rate")
+        if insurance_rate is not None:
+            return baseline, round(float(market_price) * float(insurance_rate), 2)
+
+        return baseline, None
 
     async def _resolve_zpid_from_address(self, address: str) -> str | None:
         """Resolve a Zillow zpid from a full address."""

--- a/backend/tests/test_landlord_insurance_lookup.py
+++ b/backend/tests/test_landlord_insurance_lookup.py
@@ -68,8 +68,12 @@ def test_property_service_estimate_uses_county_path() -> None:
         "county": "Palm Beach",
         "zip_code": "33414",
     }
-    out = svc._estimate_insurance(data)  # noqa: SLF001
-    assert 8_440 <= out <= 8_450
+    baseline, risk_adjusted = svc._estimate_insurance(data)  # noqa: SLF001
+    # Baseline is always the 1% market rule-of-thumb that feeds Deal Gap.
+    assert baseline == round(500_000 * 0.01, 2)
+    # Risk-adjusted uses the county ACS + state calibration methodology.
+    assert risk_adjusted is not None
+    assert 8_440 <= risk_adjusted <= 8_450
 
 
 def test_property_service_falls_back_without_county() -> None:
@@ -79,5 +83,24 @@ def test_property_service_falls_back_without_county() -> None:
         "value_iq_estimate": 500_000,
         "zip_code": "33414",
     }
-    out = svc._estimate_insurance(data)  # noqa: SLF001
-    assert out == round(500_000 * 0.018, 2)
+    baseline, risk_adjusted = svc._estimate_insurance(data)  # noqa: SLF001
+    assert baseline == round(500_000 * 0.01, 2)
+    assert risk_adjusted == round(500_000 * 0.018, 2)
+
+
+def test_property_service_no_price_returns_default_baseline_and_none_risk() -> None:
+    svc = PropertyService()
+    baseline, risk_adjusted = svc._estimate_insurance({})  # noqa: SLF001
+    assert baseline == 1500.0
+    assert risk_adjusted is None
+
+
+def test_property_service_no_county_no_zip_falls_back_to_default_region() -> None:
+    """Without county or ZIP, get_market_adjustments returns the DEFAULT region
+    (insurance_rate 0.010) — risk_adjusted equals baseline. UI is expected
+    to suppress the transparency layer when the two values match."""
+    svc = PropertyService()
+    data = {"value_iq_estimate": 500_000}  # no county, no zip_code
+    baseline, risk_adjusted = svc._estimate_insurance(data)  # noqa: SLF001
+    assert baseline == round(500_000 * 0.01, 2)
+    assert risk_adjusted == round(500_000 * 0.010, 2)


### PR DESCRIPTION
## Summary

- Splits property insurance estimate into two values: a **Market Baseline** (1% of price) that feeds the headline Deal Gap calculation, and a **Risk-Adjusted** figure (county ACS × state calibration, ZIP fallback) preserved on a new field for UI transparency.
- Solves the perception problem introduced by `1c4f8fdd`: that commit's accurate-but-high methodology was pushing too many properties into large negative Deal Gap territory vs. competitors (BiggerPockets, Mashvisor, Zillow-style calculators) who display ~1% or omit insurance entirely.
- Backend-only — the ~50 downstream consumers (formulas, IQ verdict, assumption resolver, frontend metrics) keep reading `insurance_annual` unchanged. UI surfacing of the risk-adjusted figure is intentionally deferred to a follow-up PR.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Cross-Platform Impact

- [x] **Backend API change** — Frontend AND mobile may need updates

### If this is a backend API change:

- [ ] Frontend API client has been updated *(no change required — frontend reads `insurance_annual` and now automatically picks up the new baseline value)*
- [ ] Mobile API client has been updated *(same — additive schema change is backward compatible)*
- [ ] Shared types have been updated (if applicable) *(N/A — additive optional field)*

The new `insurance_annual_risk_adjusted` field is optional and additive on `MarketData`, `OperatingAssumptions`, and `STRAssumptions`. Existing clients that ignore it continue to work; the perception fix lands the moment this deploys.

## Areas Affected

- [x] Financial calculations (insurance feeds NOI → Deal Gap)
- [x] Deal scoring / grading (multi-strategy verdict insurance inputs)
- [x] API services / data flow (MarketData payload schema)

## Test Plan

- [x] Manual testing via direct Python harness against 5 cases (see results below)
- [x] Existing test suite updated for the new `(baseline, risk_adjusted)` tuple shape
- [ ] Cross-platform test fixtures pass *(no shared fixtures touched)*
- [x] No linter errors introduced

### Verification results

Direct harness against `_estimate_insurance` with the production `county_rates.json` + `state_calibration.json` data:

| Case | Inputs | Baseline | Risk-Adjusted |
|---|---|---|---|
| Palm Beach FL | $500k, FL, Palm Beach, ZIP 33414 | $5,000 | $8,447 |
| ZIP-only fallback | $500k, ZIP 33414 (no county) | $5,000 | $9,000 |
| No price | empty dict | $1,500 | `None` |
| DEFAULT region | $500k, no geography | $5,000 | $5,000 |
| California (low risk) | $800k, ZIP 94110 | $8,000 | $4,000 |

The CA case is a noteworthy second-order effect: in low-risk states the risk-adjusted figure is *lower* than the 1% baseline, so the eventual transparency-layer UI would show users they're getting a discount vs. the rule-of-thumb.

### Pytest note

The repo's pytest collection currently fails with `AttributeError: 'Package' object has no attribute 'obj'` (pytest-asyncio 0.23.3 incompatibility) — reproducible on `main` too, not introduced by this PR. Verification was done via the direct Python harness instead.

## Notes for Reviewers

**Why this approach:** Direct analog to a competitive-positioning move from foreclosure.com vs. RealtyTrac/Attom. When accuracy makes the headline metric look worse than competitors who fudge or omit, the answer isn't to weaken the methodology — it's to reshape what's in the headline while keeping the accurate figure as a transparency/credibility layer. The county+state methodology stays intact and remains the differentiator; we just stop using it as the headline number.

**What is NOT in this PR (intentionally deferred):** A UI surface for the `insurance_annual_risk_adjusted` field. That's a copy/UX call best handled separately once we've decided exactly where the disclosure goes and how it reads ("competitors quote $X — true risk-adjusted cost is $Y based on county insurance data"). The data is in the payload and ready for that follow-up.

**Edge cases worth understanding:**
- Risk-adjusted = `None` only when `market_price` is missing entirely. With any price, the chain always resolves (county → ZIP → DEFAULT region 1%).
- When risk-adjusted equals baseline (e.g. DEFAULT region or coincidence), the eventual UI is expected to suppress the transparency layer.
- Risk-adjusted *can* be lower than baseline in low-risk states — the UI framing should handle this gracefully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)