### PR TITLE
fix(ci): unblock backend lint job + surface real test failures

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -137,7 +137,6 @@ async def lifespan(app: FastAPI):
     # migration constraints/indexes and mask failed deploy migrations.
     logger.info("Skipping runtime table creation; Alembic migrations are the schema authority")
 
-
     # Run cleanup tasks (expired sessions, tokens, old audit logs) once at startup.
     # In production, wire these into a cron schedule (e.g. Railway cron, APScheduler).
     try:

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -5,17 +5,17 @@ All models are imported here for Alembic auto-discovery.
 
 from app.models.assumption_defaults import AdminAssumptionDefaults
 from app.models.audit_log import AuditAction, AuditLog
+from app.models.budget import BudgetExpense, BudgetLine, RehabBudget
 from app.models.contact import ContactRole, PropertyContact
 from app.models.device_token import DevicePlatform, DeviceToken
 from app.models.document import Document, DocumentType
 from app.models.role import Permission, Role, RolePermission, UserRole
-from app.models.budget import BudgetExpense, BudgetLine, RehabBudget
 from app.models.saved_property import FlipStage, PropertyAdjustment, PropertyStatus, SavedProperty
-from app.models.task import PropertyTask
 from app.models.search_history import SearchHistory
 from app.models.session import UserSession
 from app.models.share import SharedLink, ShareType
 from app.models.subscription import PaymentHistory, Subscription, SubscriptionStatus, SubscriptionTier
+from app.models.task import PropertyTask
 from app.models.user import User, UserProfile
 from app.models.verification_token import TokenType, VerificationToken
 
@@ -23,12 +23,12 @@ __all__ = [
     "AdminAssumptionDefaults",
     "AuditAction",
     "AuditLog",
+    "BudgetExpense",
+    "BudgetLine",
     "ContactRole",
     "DevicePlatform",
     "DeviceToken",
     "Document",
-    "BudgetExpense",
-    "BudgetLine",
     "DocumentType",
     "FlipStage",
     "PaymentHistory",
@@ -51,7 +51,6 @@ __all__ = [
     "User",
     "UserProfile",
     "UserRole",
-    # New auth models
     "UserSession",
     "VerificationToken",
 ]

--- a/backend/app/models/budget.py
+++ b/backend/app/models/budget.py
@@ -45,11 +45,11 @@ class RehabBudget(Base):
         DateTime(timezone=True), default=lambda: datetime.now(UTC), onupdate=lambda: datetime.now(UTC)
     )
 
-    saved_property: Mapped["SavedProperty"] = relationship("SavedProperty", back_populates="rehab_budget")
-    lines: Mapped[list["BudgetLine"]] = relationship(
+    saved_property: Mapped[SavedProperty] = relationship("SavedProperty", back_populates="rehab_budget")
+    lines: Mapped[list[BudgetLine]] = relationship(
         "BudgetLine", back_populates="budget", cascade="all, delete-orphan", order_by="BudgetLine.sort_order"
     )
-    expenses: Mapped[list["BudgetExpense"]] = relationship(
+    expenses: Mapped[list[BudgetExpense]] = relationship(
         "BudgetExpense", back_populates="budget", cascade="all, delete-orphan"
     )
 
@@ -77,8 +77,8 @@ class BudgetLine(Base):
     pct_complete: Mapped[Decimal] = mapped_column(Numeric(5, 2), nullable=False, default=Decimal("0"))
     sort_order: Mapped[int] = mapped_column(default=0)
 
-    budget: Mapped["RehabBudget"] = relationship("RehabBudget", back_populates="lines")
-    expenses: Mapped[list["BudgetExpense"]] = relationship("BudgetExpense", back_populates="budget_line")
+    budget: Mapped[RehabBudget] = relationship("RehabBudget", back_populates="lines")
+    expenses: Mapped[list[BudgetExpense]] = relationship("BudgetExpense", back_populates="budget_line")
 
 
 class BudgetExpense(Base):
@@ -108,7 +108,7 @@ class BudgetExpense(Base):
 
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(UTC))
 
-    budget: Mapped["RehabBudget"] = relationship("RehabBudget", back_populates="expenses")
-    budget_line: Mapped["BudgetLine | None"] = relationship("BudgetLine", back_populates="expenses")
-    receipt_document: Mapped["Document | None"] = relationship("Document")
-    created_by: Mapped["User"] = relationship("User")
+    budget: Mapped[RehabBudget] = relationship("RehabBudget", back_populates="expenses")
+    budget_line: Mapped[BudgetLine | None] = relationship("BudgetLine", back_populates="expenses")
+    receipt_document: Mapped[Document | None] = relationship("Document")
+    created_by: Mapped[User] = relationship("User")

--- a/backend/app/models/contact.py
+++ b/backend/app/models/contact.py
@@ -80,5 +80,5 @@ class PropertyContact(Base):
         nullable=False,
     )
 
-    saved_property: Mapped["SavedProperty"] = relationship("SavedProperty", back_populates="contacts")
-    created_by: Mapped["User"] = relationship("User")
+    saved_property: Mapped[SavedProperty] = relationship("SavedProperty", back_populates="contacts")
+    created_by: Mapped[User] = relationship("User")

--- a/backend/app/models/task.py
+++ b/backend/app/models/task.py
@@ -67,6 +67,6 @@ class PropertyTask(Base):
         nullable=False,
     )
 
-    saved_property: Mapped["SavedProperty"] = relationship("SavedProperty", back_populates="tasks")
-    completed_by: Mapped["User | None"] = relationship("User", foreign_keys=[completed_by_id])
-    created_by: Mapped["User"] = relationship("User", foreign_keys=[created_by_id])
+    saved_property: Mapped[SavedProperty] = relationship("SavedProperty", back_populates="tasks")
+    completed_by: Mapped[User | None] = relationship("User", foreign_keys=[completed_by_id])
+    created_by: Mapped[User] = relationship("User", foreign_keys=[created_by_id])

--- a/backend/app/routers/saved_properties.py
+++ b/backend/app/routers/saved_properties.py
@@ -15,10 +15,6 @@ from app.core.deps import CurrentUser, DbSession
 from app.core.schema_guard import is_schema_mismatch, log_schema_mismatch
 from app.models.saved_property import FlipStage as FlipStageORM
 from app.models.saved_property import PropertyStatus
-from app.schemas.deal_maker import (
-    DealMakerRecordUpdate,
-    DealMakerResponse,
-)
 from app.schemas.budget import (
     BudgetExpenseCreate,
     BudgetExpenseOut,
@@ -27,6 +23,11 @@ from app.schemas.budget import (
     BudgetSummaryOut,
     ParsedReceipt,
     ReceiptUploadResponse,
+)
+from app.schemas.contact import ContactCreate, ContactOut, ContactUpdate
+from app.schemas.deal_maker import (
+    DealMakerRecordUpdate,
+    DealMakerResponse,
 )
 from app.schemas.saved_property import (
     ActiveFlipSummary,
@@ -39,14 +40,14 @@ from app.schemas.saved_property import (
     SavedPropertySummary,
     SavedPropertyUpdate,
 )
-from app.schemas.contact import ContactCreate, ContactOut, ContactUpdate
 from app.schemas.task import TaskCreate, TaskOut, TaskReorderRequest, TaskUpdate, UpcomingTaskOut
 from app.schemas.timeline import NoteCreate, TimelineEvent
 from app.services.billing_service import billing_service
 from app.services.budget_service import budget_service
 from app.services.contact_service import contact_service
 from app.services.deal_maker_service import DealMakerService
-from app.services.document_service import ALLOWED_TYPES as DOC_ALLOWED_TYPES, document_service
+from app.services.document_service import ALLOWED_TYPES as DOC_ALLOWED_TYPES
+from app.services.document_service import document_service
 from app.services.receipt_parser_service import receipt_parser_service
 from app.services.saved_property_service import sanitize_for_json_storage, saved_property_service
 from app.services.search_history_service import search_history_service
@@ -243,7 +244,9 @@ async def list_saved_properties(
         try:
             from datetime import datetime as _dt
 
-            from sqlalchemy import and_ as _and, func as _func, select as _select
+            from sqlalchemy import and_ as _and
+            from sqlalchemy import func as _func
+            from sqlalchemy import select as _select
 
             from app.models.task import PropertyTask
 
@@ -337,9 +340,7 @@ async def list_active_flips_endpoint(
 ):
     """Properties with a flip_stage set — Acquisition / Rehab / Listed / (optional Sold)."""
     try:
-        rows = await saved_property_service.list_active_flips(
-            db, str(current_user.id), include_sold=include_sold
-        )
+        rows = await saved_property_service.list_active_flips(db, str(current_user.id), include_sold=include_sold)
     except Exception as exc:
         # Schema-mismatch fallback: Pipeline page renders the "no active flips
         # yet" empty state instead of erroring. See app/core/schema_guard.py.
@@ -363,9 +364,7 @@ async def list_active_flips_endpoint(
             # whole pipeline — render the card without a budget badge.
             if not is_schema_mismatch(exc):
                 raise
-            log_schema_mismatch(
-                "GET /properties/saved/active-flips:budget_enrichment", exc
-            )
+            log_schema_mismatch("GET /properties/saved/active-flips:budget_enrichment", exc)
             variance_pct = None
         out.append(
             ActiveFlipSummary(
@@ -918,9 +917,7 @@ async def delete_budget_expense(
     current_user: CurrentUser,
     db: DbSession,
 ):
-    ok = await budget_service.delete_expense(
-        db, expense_id, str(current_user.id), property_id=property_id
-    )
+    ok = await budget_service.delete_expense(db, expense_id, str(current_user.id), property_id=property_id)
     if not ok:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Expense not found")
 
@@ -984,7 +981,7 @@ async def create_property_task(
     summary="Update a task (toggle complete, edit fields)",
 )
 async def update_property_task(
-    property_id: str,  # noqa: ARG001 — kept in URL for symmetry & clean ownership scoping client-side
+    property_id: str,
     task_id: str,
     body: TaskUpdate,
     current_user: CurrentUser,
@@ -1002,7 +999,7 @@ async def update_property_task(
     summary="Delete a task",
 )
 async def delete_property_task(
-    property_id: str,  # noqa: ARG001
+    property_id: str,
     task_id: str,
     current_user: CurrentUser,
     db: DbSession,
@@ -1023,9 +1020,7 @@ async def reorder_property_tasks(
     current_user: CurrentUser,
     db: DbSession,
 ):
-    updated = await task_service.reorder_for_property(
-        db, property_id, str(current_user.id), body.task_ids
-    )
+    updated = await task_service.reorder_for_property(db, property_id, str(current_user.id), body.task_ids)
     if updated is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Property not found")
     # Return the property's tasks in their new order so the client can
@@ -1118,7 +1113,7 @@ async def create_property_contact(
     summary="Update a contact",
 )
 async def update_property_contact(
-    property_id: str,  # noqa: ARG001
+    property_id: str,
     contact_id: str,
     body: ContactUpdate,
     current_user: CurrentUser,
@@ -1136,7 +1131,7 @@ async def update_property_contact(
     summary="Delete a contact",
 )
 async def delete_property_contact(
-    property_id: str,  # noqa: ARG001
+    property_id: str,
     contact_id: str,
     current_user: CurrentUser,
     db: DbSession,
@@ -1162,9 +1157,7 @@ async def list_property_timeline(
     db: DbSession,
     limit: int = Query(100, ge=1, le=500),
 ):
-    events = await timeline_service.list_for_property(
-        db, property_id, str(current_user.id), limit=limit
-    )
+    events = await timeline_service.list_for_property(db, property_id, str(current_user.id), limit=limit)
     if events is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Property not found")
     return events
@@ -1206,9 +1199,7 @@ async def delete_property_note(
     current_user: CurrentUser,
     db: DbSession,
 ):
-    ok = await timeline_service.delete_note(
-        db, property_id, str(current_user.id), adjustment_id
-    )
+    ok = await timeline_service.delete_note(db, property_id, str(current_user.id), adjustment_id)
     if not ok:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Note not found")
 

--- a/backend/app/routers/worksheet.py
+++ b/backend/app/routers/worksheet.py
@@ -540,9 +540,7 @@ async def calculate_brrrr_worksheet(input_data: BRRRRWorksheetInput, db: DbSessi
         holding_utilities = input_data.utilities_monthly * input_data.holding_months
         total_holding_costs = holding_interest + holding_taxes + holding_insurance + holding_utilities
         cash_out_at_refi = result["cash_out_at_refinance"]
-        total_cash_invested = (
-            ce + input_data.purchase_costs + points_cost + total_rehab + total_holding_costs
-        )
+        total_cash_invested = ce + input_data.purchase_costs + points_cost + total_rehab + total_holding_costs
         cash_left_in_deal = total_cash_invested - cash_out_at_refi
         annual_gross_rent = result["annual_gross_rent"]
         vacancy_loss = annual_gross_rent * input_data.vacancy_rate
@@ -551,9 +549,7 @@ async def calculate_brrrr_worksheet(input_data: BRRRRWorksheetInput, db: DbSessi
         maintenance = effective_income * input_data.maintenance_pct
         capex = effective_income * input_data.capex_pct
         hoa_annual = input_data.hoa_monthly * 12
-        total_expenses = (
-            input_data.property_taxes_annual + ia + property_management + maintenance + capex + hoa_annual
-        )
+        total_expenses = input_data.property_taxes_annual + ia + property_management + maintenance + capex + hoa_annual
         noi = effective_income - total_expenses
         annual_debt_service = result["new_monthly_pi"] * 12
         annual_cash_flow = noi - annual_debt_service

--- a/backend/app/services/budget_service.py
+++ b/backend/app/services/budget_service.py
@@ -17,9 +17,7 @@ from app.services.rehab_budget_math import compute_lines_from_selections, grand_
 
 
 class BudgetService:
-    async def get_budget_for_property(
-        self, db: AsyncSession, property_id: str, user_id: str
-    ) -> RehabBudget | None:
+    async def get_budget_for_property(self, db: AsyncSession, property_id: str, user_id: str) -> RehabBudget | None:
         result = await db.execute(
             select(RehabBudget)
             .join(SavedProperty, SavedProperty.id == RehabBudget.saved_property_id)
@@ -203,8 +201,7 @@ class BudgetService:
             "variance_pct": str(variance_pct),
             "lines": line_rows,
             "categories": {
-                k: {"estimate": str(v["estimate"]), "actual": str(v["actual"])}
-                for k, v in cat_rollups.items()
+                k: {"estimate": str(v["estimate"]), "actual": str(v["actual"])} for k, v in cat_rollups.items()
             },
         }
 

--- a/backend/app/services/calculators/brrrr.py
+++ b/backend/app/services/calculators/brrrr.py
@@ -7,7 +7,6 @@ No imports from app.core.defaults allowed.
 from typing import Any
 
 from .common import (
-    calculate_monthly_mortgage,
     cash_needed_after_seller,
     combined_bank_and_seller_pi,
     conventional_first_lien_loan,

--- a/backend/app/services/calculators/flip.py
+++ b/backend/app/services/calculators/flip.py
@@ -49,9 +49,7 @@ def calculate_flip(
     purchase_price = market_value * (1 - purchase_discount_pct)
     nominal_equity = purchase_price * (1 - hard_money_ltv)
     sc = max(0.0, float(seller_carry_amount or 0.0))
-    hard_money_loan, cash_equity_at_close = model_a_bank_loan_and_cash_equity(
-        purchase_price, nominal_equity, sc
-    )
+    hard_money_loan, cash_equity_at_close = model_a_bank_loan_and_cash_equity(purchase_price, nominal_equity, sc)
     down_payment = nominal_equity
     closing_costs = purchase_price * closing_costs_pct
     total_acquisition_cash = cash_equity_at_close + closing_costs + inspection_costs

--- a/backend/app/services/calculators/ltr.py
+++ b/backend/app/services/calculators/ltr.py
@@ -12,7 +12,6 @@ from .common import (
     calculate_cash_on_cash,
     calculate_dscr,
     calculate_grm,
-    calculate_monthly_mortgage,
     cash_needed_after_seller,
     combined_bank_and_seller_pi,
     conventional_first_lien_loan,

--- a/backend/app/services/contact_service.py
+++ b/backend/app/services/contact_service.py
@@ -14,9 +14,7 @@ from app.schemas.contact import ContactCreate, ContactUpdate
 
 
 class ContactService:
-    async def _ensure_owns_property(
-        self, db: AsyncSession, property_id: str, user_id: str
-    ) -> SavedProperty | None:
+    async def _ensure_owns_property(self, db: AsyncSession, property_id: str, user_id: str) -> SavedProperty | None:
         result = await db.execute(
             select(SavedProperty).where(
                 SavedProperty.id == uuid.UUID(property_id),
@@ -25,9 +23,7 @@ class ContactService:
         )
         return result.scalar_one_or_none()
 
-    async def list_for_property(
-        self, db: AsyncSession, property_id: str, user_id: str
-    ) -> list[PropertyContact] | None:
+    async def list_for_property(self, db: AsyncSession, property_id: str, user_id: str) -> list[PropertyContact] | None:
         if not await self._ensure_owns_property(db, property_id, user_id):
             return None
         result = await db.execute(

--- a/backend/app/services/deal_maker_service.py
+++ b/backend/app/services/deal_maker_service.py
@@ -95,9 +95,7 @@ class DealMakerService:
 
         if zip_code:
             market = get_market_adjustments(zip_code)
-            assumptions_dict = assumptions.model_dump(
-                exclude={"vacancy_rate", "appreciation_rate", "market_region"}
-            )
+            assumptions_dict = assumptions.model_dump(exclude={"vacancy_rate", "appreciation_rate", "market_region"})
             assumptions = InitialAssumptions(
                 **assumptions_dict,
                 vacancy_rate=market.get("vacancy_rate", o.vacancy_rate),

--- a/backend/app/services/deal_structures/formatting.py
+++ b/backend/app/services/deal_structures/formatting.py
@@ -1,4 +1,4 @@
-# ruff: noqa: RUF001, RUF002
+# ruff: noqa: RUF001
 # Currency formatters use U+2212 (MINUS SIGN) instead of U+002D (HYPHEN-MINUS) for typographic
 # correctness — '−$25K' renders properly across fonts where '-$25K' looks like a stray hyphen.
 """Shared formatting helpers for deal-structure copy."""

--- a/backend/app/services/deal_structures/narrative.py
+++ b/backend/app/services/deal_structures/narrative.py
@@ -104,11 +104,7 @@ def _paragraph_for(structure: DealStructure, ctx: StructureContext, index: int) 
 
     if sid == "blended-plan":
         new_rent = next(
-            (
-                lever.after_label
-                for lever in structure.levers
-                if lever.label.lower() in ("monthly rent", "target rent")
-            ),
+            (lever.after_label for lever in structure.levers if lever.label.lower() in ("monthly rent", "target rent")),
             "a small bump",
         )
         carry_label = next(

--- a/backend/app/services/deal_structures/templates/assumable.py
+++ b/backend/app/services/deal_structures/templates/assumable.py
@@ -35,7 +35,11 @@ def solve(ctx: StructureContext) -> DealStructure | None:
     rate = ctx.estimated_existing_loan_rate
     if bal is None or bal <= 0 or rate is None or rate <= 0:
         # Fall back to Sub2-style balance if we at least have a last sale
-        if ctx.estimated_purchase_year is None or ctx.estimated_purchase_price is None or ctx.estimated_purchase_price <= 0:
+        if (
+            ctx.estimated_purchase_year is None
+            or ctx.estimated_purchase_price is None
+            or ctx.estimated_purchase_price <= 0
+        ):
             return None
         assumed_rate = sub2_mod._rate_for_purchase_year(ctx.estimated_purchase_year)
         if assumed_rate is None:
@@ -101,7 +105,7 @@ def solve(ctx: StructureContext) -> DealStructure | None:
         "EDUCATE FIRST — most agents miss this\n"
         f"\"The seller's existing loan is {lt} — those are formally assumable by a qualified "
         "buyer. Has the seller looked into letting a buyer assume the loan instead of paying it "
-        "off at closing? It changes the numbers significantly for both sides.\"\n\n"
+        'off at closing? It changes the numbers significantly for both sides."\n\n'
         "WHY IT'S A WIN FOR THE SELLER (lead with this)\n"
         f"1. The property becomes attractive to a much larger buyer pool — buyers can take a "
         f"{note_rate * 100:.2f}% loan vs. originating new at {ctx.interest_rate * 100:.2f}%.\n"
@@ -117,31 +121,31 @@ def solve(ctx: StructureContext) -> DealStructure | None:
         f"{fmt_money_precise(pv)} in present value. Some of that savings can be passed back to the "
         "seller through stronger price or terms — don't be greedy.\n\n"
         "THE STRUCTURE OF THE OFFER\n"
-        f"\"My offer is to formally assume the existing {lt} loan at the current balance of "
+        f'"My offer is to formally assume the existing {lt} loan at the current balance of '
         f"approximately {fmt_money(balance)}, plus a cash payment to the seller for their equity. "
         f"That equity check would be approximately {fmt_money(equity_check)} — call it gross "
         "equity less my standard closing costs and reserves. I'd close in 60-90 days to "
         "accommodate the lender's assumption underwriting.\"\n\n"
         "ANTICIPATE OBJECTIONS\n"
-        "\u2022 \"60-90 days is too long\" \u2192 \"It's slower than a regular sale, true. In "
+        '\u2022 "60-90 days is too long" \u2192 "It\'s slower than a regular sale, true. In '
         "exchange, you get a buyer who is fully qualified through the existing lender — almost no "
         "risk of falling out. And the seller's headline price stays whole because I'm not asking "
-        "for a discount on price.\"\n"
-        "\u2022 \"Why should the seller bother?\" \u2192 \"Because most buyers can't bring this much "
+        'for a discount on price."\n'
+        '\u2022 "Why should the seller bother?" \u2192 "Because most buyers can\'t bring this much '
         "cash AND get a loan at this rate. The seller is selling into a buyer pool of one — me. "
         "That's leverage for the seller, not for me.\"\n"
-        "\u2022 \"Will the lender approve you?\" \u2192 \"I'll submit my full credit and income "
+        '\u2022 "Will the lender approve you?" \u2192 "I\'ll submit my full credit and income '
         "package the day you accept the offer. The lender's underwriting is similar to a regular "
         "FHA approval — I've already been pre-qualified.\"\n\n"
         "TRIAL CLOSE\n"
-        "\"If the seller is open to letting me assume the loan, I can have a clean offer with proof "
+        '"If the seller is open to letting me assume the loan, I can have a clean offer with proof '
         "of funds in your inbox within 24 hours. Should I get the assumption package started with "
-        "the servicer in parallel?\"\n\n"
+        'the servicer in parallel?"\n\n'
         "TACTICS\n"
         "\u2022 Confirm the loan is currently assumable — call the servicer; some FHA loans pre-1989 are unrestricted, post-1989 require credit qualification.\n"
         "\u2022 Lock the property up early — 30-day inspection, then 60-90 day close to accommodate underwriting.\n"
         "\u2022 If the seller wants to buy again with another FHA, they may not want to let go of the loan — discuss timing of their next purchase.\n"
-        f"\u2022 Get pre-qualified through an FHA-approved lender BEFORE you make the offer. \"I'm already pre-approved\" is the strongest trust signal you can offer."
+        f'\u2022 Get pre-qualified through an FHA-approved lender BEFORE you make the offer. "I\'m already pre-approved" is the strongest trust signal you can offer.'
         f"{va_warning}"
     )
 

--- a/backend/app/services/deal_structures/templates/blended_plan.py
+++ b/backend/app/services/deal_structures/templates/blended_plan.py
@@ -240,16 +240,13 @@ def solve(
     bump_pct = (rent_bump / ctx.monthly_rent * 100) if ctx.monthly_rent > 0 else 0.0
     price_pct = ((ctx.list_price - new_price) / ctx.list_price * 100) if ctx.list_price > 0 else 0.0
 
-    headline = (
-        f"Blend: {price_pct:.1f}% price cut + {fmt_money(chosen_second)} seller 2nd + "
-        f"{bump_pct:.1f}% rent lift"
-    )
+    headline = f"Blend: {price_pct:.1f}% price cut + {fmt_money(chosen_second)} seller 2nd + {bump_pct:.1f}% rent lift"
     # Bullets carry the full math for the blended card (no separate lever block on the card).
     # Each bullet uses the "Label: before → after" pattern for at-a-glance scanning.
     bullets = [
-        f"Target price:\u00A0{fmt_money(ctx.list_price)} → {fmt_money(new_price)}",
-        f"Seller 2nd:\u00A0{fmt_money(chosen_second)} → 0%, {DEFAULT_BALLOON_YEARS}yr balloon",
-        f"Target Rent:\u00A0${round(ctx.monthly_rent):,} → ${round(new_rent):,}  +{bump_pct:.1f}%",
+        f"Target price:\u00a0{fmt_money(ctx.list_price)} → {fmt_money(new_price)}",
+        f"Seller 2nd:\u00a0{fmt_money(chosen_second)} → 0%, {DEFAULT_BALLOON_YEARS}yr balloon",
+        f"Target Rent:\u00a0${round(ctx.monthly_rent):,} → ${round(new_rent):,}  +{bump_pct:.1f}%",
     ]
     # Combined selection-reason + savings so the card only renders one supporting paragraph.
     summary = (
@@ -283,11 +280,11 @@ def solve(
         "OPEN — discover before you ask\n"
         "\"Before I send a number, can you walk me through what's driving the sale and where the "
         "seller would ideally land? I have a structure in mind that I think can get us close to "
-        "their number — but I want to understand their situation first.\"\n\n"
+        'their number — but I want to understand their situation first."\n\n'
         "ANCHOR — frame the gap honestly\n"
         f"\"At {fmt_money_precise(ctx.list_price)}, the deal doesn't pencil for me. But I don't "
         "think it has to come down to a single big concession. I'd like to propose a blended "
-        "structure where we share the lift across three small moves.\"\n\n"
+        'structure where we share the lift across three small moves."\n\n'
         "THE PROPOSAL — three small asks instead of one big one\n"
         f"1. PRICE — {fmt_pct_delta(ctx.list_price, new_price)} from asking, to "
         f"{fmt_money_precise(new_price)}. A modest cut, not a haircut.\n"
@@ -323,9 +320,9 @@ def solve(
         "papers the second so the seller's counsel has clean documents to review.\"\n\n"
         "TACTICS\n"
         "\u2022 Always offer 2-3 options. Sellers pick between options; they say no to single asks.\n"
-        "\u2022 Lead with the seller's situation. \"Help me understand...\" beats \"I need...\" every time.\n"
-        "\u2022 Use the words \"creative offer\" early — the agent and seller can prep for an unusual structure.\n"
-        "\u2022 Have an attorney lined up before the call. \"My attorney will paper this\" is a trust signal.\n"
+        '\u2022 Lead with the seller\'s situation. "Help me understand..." beats "I need..." every time.\n'
+        '\u2022 Use the words "creative offer" early — the agent and seller can prep for an unusual structure.\n'
+        '\u2022 Have an attorney lined up before the call. "My attorney will paper this" is a trust signal.\n'
         "\u2022 Trade concessions for concessions — never give without getting (faster close, leaseback, fewer contingencies)."
     )
 

--- a/backend/app/services/deal_structures/templates/fha_house_hack.py
+++ b/backend/app/services/deal_structures/templates/fha_house_hack.py
@@ -127,7 +127,7 @@ def solve(ctx: StructureContext) -> DealStructure | None:
         ranking_score=min(100.0, max(0.0, ranking)),
         pitch_script=(
             "WHO TO CALL\n"
-            "Yourself first — this is a strategy switch from \"investor\" to \"owner-occupant.\" "
+            'Yourself first — this is a strategy switch from "investor" to "owner-occupant." '
             "Then the listing agent, where this becomes your strongest offer-position lever.\n\n"
             "WHY YOU'RE CHANGING THE PLAY\n"
             "The deal can't work as a pure investor — but it CAN work as an owner-occupant using FHA. "
@@ -141,16 +141,16 @@ def solve(ctx: StructureContext) -> DealStructure | None:
             "than an investor. Use that. FHA also requires a stricter appraisal, which signals "
             "you're serious and can't easily walk during inspection.\n\n"
             "PITCH TO THE LISTING AGENT\n"
-            f"\"My offer is FHA financing, {FHA_DOWN_PCT * 100:.1f}% down, owner-occupant. My "
+            f'"My offer is FHA financing, {FHA_DOWN_PCT * 100:.1f}% down, owner-occupant. My '
             "family and I plan to live in the property and rent the other "
             f"{mode}. I'm pre-approved through an FHA-approved lender and ready to move on "
             "the inspection within a week. Could the seller's preference between an owner-occupant "
-            "and an investor help us get to terms?\"\n\n"
+            'and an investor help us get to terms?"\n\n'
             "OFFER COVER LETTER (when allowed by state/agent)\n"
-            "\"My family and I plan to live in the [unit/upstairs] and rent the rest while we "
+            '"My family and I plan to live in the [unit/upstairs] and rent the rest while we '
             "settle into the neighborhood. We've already been pre-approved for FHA financing and "
             "can close within 30 days. We love what you've done with the property and would be "
-            "honored to make it our home.\"\n\n"
+            'honored to make it our home."\n\n'
             "PROTECT YOURSELF — FHA APPRAISAL RED FLAGS\n"
             "FHA appraisers flag and require fixes for:\n"
             "\u2022 Peeling paint (especially on pre-1978 construction — lead paint concern)\n"
@@ -162,7 +162,7 @@ def solve(ctx: StructureContext) -> DealStructure | None:
             "If any are present, negotiate seller fixes or a credit at closing.\n\n"
             "TACTICS\n"
             "\u2022 You must occupy the property within 60 days of closing and live there at least 1 year — non-negotiable per FHA rules.\n"
-            "\u2022 After year 1, you can move out and keep the property as a rental — this is the classic \"house-hack\" wealth ladder.\n"
+            '\u2022 After year 1, you can move out and keep the property as a rental — this is the classic "house-hack" wealth ladder.\n'
             "\u2022 You can only have one FHA loan at a time (with rare exceptions). Plan accordingly.\n"
             "\u2022 FHA requires Mortgage Insurance Premium (MIP) for the life of the loan in most cases — refinance to conventional once you have 20% equity to drop it.\n"
             "\u2022 If the property is 2-4 units, your FHA loan limit is higher than for a single-family — confirm with your lender."

--- a/backend/app/services/deal_structures/templates/larger_down.py
+++ b/backend/app/services/deal_structures/templates/larger_down.py
@@ -3,7 +3,7 @@
 from app.schemas.deal_structures import DealStructure, StructureLever
 from app.services.calculators import calculate_monthly_mortgage
 from app.services.deal_structures.context import StructureContext
-from app.services.deal_structures.formatting import fmt_money, fmt_money_precise, fmt_pct_delta
+from app.services.deal_structures.formatting import fmt_money, fmt_money_precise
 
 FAMILY = "capital_stack"
 FAMILY_LABEL = "More equity"
@@ -65,10 +65,7 @@ def solve(ctx: StructureContext) -> DealStructure | None:
 
     sel_reason = "Putting more cash down is often the fastest way to clear a modest gap."
     if gap_pct < 10:
-        sel_reason = (
-            f"The gap is under {gap_pct:.0f}% — extra equity may be enough "
-            "without renegotiating price."
-        )
+        sel_reason = f"The gap is under {gap_pct:.0f}% — extra equity may be enough without renegotiating price."
 
     extra_cash = new_cash - ctx.baseline_cash_required
     cash_tradeoff_years = (extra_cash / (monthly_savings * 12)) if monthly_savings > 0 else 0
@@ -92,10 +89,10 @@ def solve(ctx: StructureContext) -> DealStructure | None:
         "USE THIS AS LEVERAGE WITH THE SELLER\n"
         "Bigger down = stronger offer. Don't just bring more cash quietly — translate it into price.\n\n"
         "PITCH TO THE LISTING AGENT:\n"
-        f"\"My offer is {new_down * 100:.0f}% down at {fmt_money_precise(ctx.list_price)}, fast "
+        f'"My offer is {new_down * 100:.0f}% down at {fmt_money_precise(ctx.list_price)}, fast '
         "close, no financing contingency, no appraisal contingency on the gap. That's a buyer "
         "the seller can actually count on closing. In exchange for that certainty, what's the "
-        "lowest the seller would take?\"\n\n"
+        'lowest the seller would take?"\n\n'
         "BETTER YET — STACK CASH STRENGTH WITH A PRICE ASK:\n"
         f"\"I'll bring {new_down * 100:.0f}% down — significantly more than a typical buyer — if "
         "the seller meets me on price. Less risk for them at close, real savings for me on the "
@@ -118,10 +115,10 @@ def solve(ctx: StructureContext) -> DealStructure | None:
         # cards in the row share a consistent leading anchor (every option
         # implies a buy at this price; only the structure changes).
         bullets=[
-            f"Offer price:\u00A0{fmt_money(ctx.list_price)}",
-            f"Down payment:\u00A0{ctx.down_payment_pct * 100:.0f}% → "
+            f"Offer price:\u00a0{fmt_money(ctx.list_price)}",
+            f"Down payment:\u00a0{ctx.down_payment_pct * 100:.0f}% → "
             f"{new_down * 100:.0f}%  ({fmt_money(new_down * ctx.list_price)})",
-            f"Monthly P&I:\u00A0${round(ctx.baseline_monthly_pi):,} → ${round(new_pi):,}",
+            f"Monthly P&I:\u00a0${round(ctx.baseline_monthly_pi):,} → ${round(new_pi):,}",
         ],
         summary=(
             f"Adds about {fmt_money(delta_cash)} cash vs baseline closing but saves "

--- a/backend/app/services/deal_structures/templates/morby_method.py
+++ b/backend/app/services/deal_structures/templates/morby_method.py
@@ -48,20 +48,20 @@ def combine(sub2_result: DealStructure, seller_second_result: DealStructure, _ct
         "STAGED PITCH — don't dump both in the first sentence\n"
         "Stage 1 — Discovery: \"Before I put a number on the table, can you walk me through what's "
         "driving the sale and what your ideal closing day looks like? Are you trying to clear the "
-        "mortgage, free up cash, relocate, or something else?\"\n\n"
-        "Stage 2 — The frame: \"I have a creative structure that lets you walk away clean and gets "
+        'mortgage, free up cash, relocate, or something else?"\n\n'
+        'Stage 2 — The frame: "I have a creative structure that lets you walk away clean and gets '
         "you very close to your full asking price. It has two parts and I'd like to walk you "
-        "through both.\"\n\n"
+        'through both."\n\n'
         "Stage 3 — Sub2 leg: \"First, I'd take over the existing mortgage — your bank keeps "
         "getting paid on time, every month, but you're no longer responsible. The deed comes to "
-        "me and the loan stays in your name with full legal protections for you.\"\n\n"
-        "Stage 4 — Seller-second leg: \"Second, the equity above the loan balance — roughly the "
+        'me and the loan stays in your name with full legal protections for you."\n\n'
+        'Stage 4 — Seller-second leg: "Second, the equity above the loan balance — roughly the '
         f"difference between your asking price and the loan payoff — I'd ask you to carry as a 0% "
         f"second mortgage for {DEFAULT_BALLOON_YEARS} years. At the end of that term I refinance, "
-        "and you receive a single check for the full amount.\"\n\n"
-        f"Stage 5 — The number: \"All in, my offer is {fmt_money_precise(list_price)} — full ask. "
+        'and you receive a single check for the full amount."\n\n'
+        f'Stage 5 — The number: "All in, my offer is {fmt_money_precise(list_price)} — full ask. '
         f"You walk away with a clean exit on the first mortgage and "
-        f"{fmt_money_precise(seller_carry)} secured against the property as your second.\"\n\n"
+        f'{fmt_money_precise(seller_carry)} secured against the property as your second."\n\n'
         "WHAT'S IN IT FOR THE SELLER\n"
         "1. Full asking price (or very close) — preserves comps, ego, and tax basis story.\n"
         "2. The existing mortgage gets paid every month, on time, by me. Their credit stays clean.\n"
@@ -70,22 +70,22 @@ def combine(sub2_result: DealStructure, seller_second_result: DealStructure, _ct
         "4. Fast close (no new lender to underwrite the first), single payoff check at end.\n"
         "5. If they have capital-gains tax concerns, the installment-sale spread can help — talk to a CPA.\n\n"
         "ADDRESS BOTH FEARS UPFRONT (don't wait for objections)\n"
-        "\u2022 \"Due-on-sale clause on the existing loan\" \u2192 \"Banks rarely call performing "
+        '\u2022 "Due-on-sale clause on the existing loan" \u2192 "Banks rarely call performing '
         "loans. We use a land trust to keep the bank from seeing the title transfer, and a "
         "third-party servicer to document every payment. If I miss one, you can take the property "
-        "back through the trust.\"\n"
-        "\u2022 \"What if you don't refinance the second in time?\" \u2192 \"You're in second "
+        'back through the trust."\n'
+        '\u2022 "What if you don\'t refinance the second in time?" \u2192 "You\'re in second '
         "position behind the bank. If I default, you can foreclose and reclaim the property — and "
         "all the equity I've built sitting on top of you protects your principal.\"\n"
-        "\u2022 \"Why both at once?\" \u2192 \"Because the existing loan covers the bulk of the "
-        "price, and your second covers your equity. Two pieces, no new bank loan, full price to you.\"\n\n"
+        '\u2022 "Why both at once?" \u2192 "Because the existing loan covers the bulk of the '
+        'price, and your second covers your equity. Two pieces, no new bank loan, full price to you."\n\n'
         "TRIAL CLOSE\n"
-        "\"Would you be open to seeing this on paper? My creative-finance attorney drafts the "
+        '"Would you be open to seeing this on paper? My creative-finance attorney drafts the '
         "trust and the second-mortgage note, and your attorney reviews everything. No commitment "
         "from you until you've seen the structure and your attorney has signed off.\"\n\n"
         "TACTICS\n"
         "\u2022 NEVER pitch this in the first 60 seconds. Build rapport, hear the seller's pain, then offer the solution.\n"
-        "\u2022 Soft yes/no asks: \"Would you be open to...\" — Pace Morby's go-to opener.\n"
+        '\u2022 Soft yes/no asks: "Would you be open to..." — Pace Morby\'s go-to opener.\n'
         "\u2022 Always reference attorneys on both sides — sellers trust paper that looks professional.\n"
         "\u2022 Use a third-party loan servicer (e.g., Note Servicing Center) — documentation is your protection AND the seller's.\n"
         "\u2022 If they balk at 0% on the second, counter with 2-3% — still cheaper than a HELOC.\n"
@@ -119,10 +119,7 @@ def combine(sub2_result: DealStructure, seller_second_result: DealStructure, _ct
             )
         )
 
-    caveat = (
-        f"{sub2_result.caveat or ''} "
-        f"{seller_second_result.caveat or ''}".strip()
-    )
+    caveat = f"{sub2_result.caveat or ''} {seller_second_result.caveat or ''}".strip()
 
     sel_reason = (
         "Shown because both taking over the seller's loan and a 0% seller second can work here—"

--- a/backend/app/services/deal_structures/templates/price_negotiation.py
+++ b/backend/app/services/deal_structures/templates/price_negotiation.py
@@ -62,21 +62,21 @@ def solve(ctx: StructureContext) -> DealStructure | None:
         f"driving the sale and where the seller would ideally land? I see the property has been "
         f"{dom_phrase} — what's the seller's read on the activity so far?\"\n\n"
         "ANCHOR — lead with math, not opinion\n"
-        f"\"Based on what this property can rent for and standard operating costs in the area, my "
+        f'"Based on what this property can rent for and standard operating costs in the area, my '
         f"number is {fmt_money_precise(new_price)}. That's not a lowball — that's the price where "
         f"the monthly payment ({fmt_money_precise(monthly_pi_new)}/mo P&I) actually pencils for an "
         f"investor who'd close in cash and on time. At {fmt_money_precise(ctx.list_price)} the "
         f"payment is {fmt_money_precise(monthly_pi_now)}/mo and the deal loses money every single "
-        "month from day one.\"\n\n"
+        'month from day one."\n\n'
         "ASK — one number, then go silent\n"
-        f"\"My offer is {fmt_money_precise(new_price)}. Cash, fast close, no financing contingency, "
+        f'"My offer is {fmt_money_precise(new_price)}. Cash, fast close, no financing contingency, '
         "and I'm flexible on the seller's preferred close date. Would they meet me there?\"\n\n"
         "(Stop talking. The next person to speak loses leverage.)\n\n"
         "HANDLE PUSHBACK — Chris Voss calibrated question\n"
         "If they push back on the number, don't argue or split the difference. Instead:\n"
-        f"\"I hear you. How am I supposed to make this work at {fmt_money_precise(ctx.list_price)} "
+        f'"I hear you. How am I supposed to make this work at {fmt_money_precise(ctx.list_price)} '
         "when the rents won't cover the mortgage? Help me understand the seller's thinking on "
-        "price — what comps are they looking at?\"\n\n"
+        'price — what comps are they looking at?"\n\n'
         "TRADE A CONCESSION FOR A CONCESSION\n"
         "If they need a higher number, ask for something in return:\n"
         "\u2022 Faster close (cash certainty is worth real dollars)\n"
@@ -84,26 +84,22 @@ def solve(ctx: StructureContext) -> DealStructure | None:
         "\u2022 Seller-paid closing costs\n"
         "\u2022 Appliances, repair credits, or as-is sale with no inspection ask\n\n"
         "TRIAL CLOSE\n"
-        "\"If we can agree on price, I can have a clean offer and proof of funds in your inbox "
-        "today. What would it take to get this signed by end of week?\"\n\n"
+        '"If we can agree on price, I can have a clean offer and proof of funds in your inbox '
+        'today. What would it take to get this signed by end of week?"\n\n'
         "TACTICS\n"
         "\u2022 State your number once, then stay quiet. Sellers fill silence with concessions.\n"
-        "\u2022 Never explain your math unless asked. \"My number\" is more powerful than a spreadsheet.\n"
-        "\u2022 Always reference the seller's situation, never your own. \"My number is...\" not \"I need...\".\n"
+        '\u2022 Never explain your math unless asked. "My number" is more powerful than a spreadsheet.\n'
+        '\u2022 Always reference the seller\'s situation, never your own. "My number is..." not "I need...".\n'
         "\u2022 If the listing has been stale, mention it gently — it's leverage. If it's fresh, don't.\n"
         "\u2022 Walk away once. Sellers often call back within 48 hours."
     )
 
     if ctx.days_on_market and ctx.days_on_market > 60:
         sel_reason = (
-            f"The property has been listed {ctx.days_on_market} days. "
-            "Seller's price flexibility is more likely."
+            f"The property has been listed {ctx.days_on_market} days. Seller's price flexibility is more likely."
         )
     else:
-        sel_reason = (
-            "The seller's personal and financial situation will indicate "
-            "if price flexibility is more likely."
-        )
+        sel_reason = "The seller's personal and financial situation will indicate if price flexibility is more likely."
 
     return DealStructure(
         id=ID,

--- a/backend/app/services/deal_structures/templates/rate_buydown.py
+++ b/backend/app/services/deal_structures/templates/rate_buydown.py
@@ -1,4 +1,4 @@
-"""2-1 seller-paid rate buydown — lower effective rate years 1–2."""  # noqa: RUF002 — en dash is deliberate range typography
+"""2-1 seller-paid rate buydown — lower effective rate years 1–2."""
 
 from app.schemas.deal_structures import DealStructure, StructureLever
 from app.services.calculators import calculate_monthly_mortgage
@@ -49,11 +49,11 @@ def solve(ctx: StructureContext) -> DealStructure | None:
 
     sel_reason = "Shown because a seller-paid buydown lowers year-one payments without cutting price"
     if ctx.days_on_market and ctx.days_on_market > 30:
-        sel_reason = f"Shown because the listing has been active {ctx.days_on_market} days — sellers often help with financing"
+        sel_reason = (
+            f"Shown because the listing has been active {ctx.days_on_market} days — sellers often help with financing"
+        )
 
-    is_new_construction = (
-        ctx.year_built is not None and abs(ctx.year_built - 2026) <= 2
-    )
+    is_new_construction = ctx.year_built is not None and abs(ctx.year_built - 2026) <= 2
     audience_line = (
         "Builder's sales agent — new-construction sellers love this structure because it preserves "
         "the headline price (which protects future comps in the development).\n"
@@ -76,25 +76,25 @@ def solve(ctx: StructureContext) -> DealStructure | None:
         "OPEN — frame it as price-preserving (not a discount)\n"
         f"\"We've underwritten this carefully. At {fmt_money_precise(ctx.list_price)}, the year-one "
         "cash flow is too tight to commit. Rather than ask the seller to cut price — which hurts "
-        "their comps and their net — would they consider a 2-1 rate buydown instead?\"\n\n"
+        'their comps and their net — would they consider a 2-1 rate buydown instead?"\n\n'
         "ASK — be specific so they can say yes\n"
-        f"\"My ask is a seller-paid 2-1 temporary buydown. First year at {y1_rate * 100:.1f}%, "
+        f'"My ask is a seller-paid 2-1 temporary buydown. First year at {y1_rate * 100:.1f}%, '
         f"second year at {y2_rate * 100:.1f}%, then the note rate of {note * 100:.1f}% kicks in. "
         f"My lender estimates the concession at roughly {fmt_money(approx_cost)} — they can write "
         "the exact figure into the offer. The seller's headline price stays at "
-        f"{fmt_money_precise(ctx.list_price)}.\"\n\n"
+        f'{fmt_money_precise(ctx.list_price)}."\n\n'
         "ANTICIPATE OBJECTIONS\n"
-        f"\u2022 \"Why should we pay for the buyer's rate?\" \u2192 \"Because at "
+        f'\u2022 "Why should we pay for the buyer\'s rate?" \u2192 "Because at '
         f"{fmt_money(approx_cost)} of concessions, the seller nets more than they would after a "
-        "$10-15K price cut. Their comps stay strong and the deal closes.\"\n"
-        "\u2022 \"What happens in year three?\" \u2192 \"By then I've stabilized rents and refi'd "
+        '$10-15K price cut. Their comps stay strong and the deal closes."\n'
+        '\u2022 "What happens in year three?" \u2192 "By then I\'ve stabilized rents and refi\'d '
         "into a better long-term loan, or the property carries the note rate cleanly. Your concern "
-        "ends at closing.\"\n"
-        "\u2022 \"Why not just lower price?\" \u2192 \"A buydown gives me the same monthly relief "
+        'ends at closing."\n'
+        '\u2022 "Why not just lower price?" \u2192 "A buydown gives me the same monthly relief '
         "without dropping the closing comp. Net to seller is similar — but the next listing in this "
-        "neighborhood prices off your sale.\"\n\n"
+        'neighborhood prices off your sale."\n\n'
         "TRIAL CLOSE\n"
-        f"\"If the seller is open to roughly {fmt_money(approx_cost)} in closing-cost concessions, "
+        f'"If the seller is open to roughly {fmt_money(approx_cost)} in closing-cost concessions, '
         "I can have a clean offer at full price signed by end of week. Want me to put my lender on "
         "a quick call with the seller's lender to confirm the structure?\"\n\n"
         "TACTICS\n"

--- a/backend/app/services/deal_structures/templates/rent_uplift.py
+++ b/backend/app/services/deal_structures/templates/rent_uplift.py
@@ -2,7 +2,7 @@
 
 from app.schemas.deal_structures import DealStructure, StructureLever
 from app.services.deal_structures.context import StructureContext
-from app.services.deal_structures.formatting import fmt_money_precise, fmt_monthly, fmt_pct_delta
+from app.services.deal_structures.formatting import fmt_money_precise, fmt_pct_delta
 
 FAMILY = "income"
 FAMILY_LABEL = "Rent increase"
@@ -58,20 +58,20 @@ def solve(ctx: StructureContext) -> DealStructure | None:
         "1. Rentometer / Zillow Rental Manager — pull comps within 1 mile, same beds/baths, same "
         "condition tier. Note the median, not the high.\n"
         "2. Call 2 local property managers. Script: \"I'm under contract on [address] and weighing "
-        "what to charge. If I asked you to manage it, what would you list it at?\" PMs underwrite "
+        'what to charge. If I asked you to manage it, what would you list it at?" PMs underwrite '
         "rent for a living and tell you the truth — they want the listing.\n"
         "3. Walk 3 active rental listings nearby. Take photos. Honestly assess condition gap.\n"
         "4. If rehab is required to hit the higher rent, model the rehab cost AND the months of "
         "lost rent in Strategy before committing.\n\n"
         "IF VERIFIED \u2014 SEND THE OFFER AT ASKING\n"
-        f"\"My offer is at the asking price of {fmt_money_precise(ctx.list_price)}. My numbers "
+        f'"My offer is at the asking price of {fmt_money_precise(ctx.list_price)}. My numbers '
         "work because I've verified market rent at "
         f"${round(new_rent):,}/mo with two local property managers and three active comps. Clean "
-        "offer in your inbox today.\"\n\n"
+        'offer in your inbox today."\n\n'
         "IF NOT VERIFIED \u2014 PIVOT TO PRICE\n"
         f"\"Comps came in lighter than I'd hoped — closer to ${round(ctx.monthly_rent):,}/mo. To "
         "make the math work at that rent level, my number has to come down. What's the lowest the "
-        "seller would entertain?\"\n\n"
+        'seller would entertain?"\n\n'
         "TACTICS\n"
         "\u2022 NEVER raise your offer based on a rent estimate from anyone who isn't willing to "
         "manage the unit themselves. Online estimates are starting points, not truth.\n"
@@ -101,8 +101,7 @@ def solve(ctx: StructureContext) -> DealStructure | None:
         # for visual weight on the Rent Increase card.
         bullets=[
             "Target Rent:",
-            f"${round(ctx.monthly_rent):,} + ${bump_dollars:,} → "
-            f"${round(new_rent):,}  {pct_label}",
+            f"${round(ctx.monthly_rent):,} + ${bump_dollars:,} → ${round(new_rent):,}  {pct_label}",
         ],
         # Compact closing line — points the user to the deeper tool instead of
         # restating the math already shown above.

--- a/backend/app/services/deal_structures/templates/seller_second_zero_balloon.py
+++ b/backend/app/services/deal_structures/templates/seller_second_zero_balloon.py
@@ -96,14 +96,14 @@ def solve(ctx: StructureContext) -> DealStructure | None:
         "OPEN — discover before you pitch\n"
         "\"Before I send a number, I want to understand the seller's situation. What's pushing the "
         "sale, and what would a perfect closing look like for them? Are they buying another "
-        "property, paying off debt, or is this more about timing?\"\n\n"
+        'property, paying off debt, or is this more about timing?"\n\n'
         "THE PITCH — full price, creative terms\n"
-        f"\"I can pay full asking — {fmt_money_precise(ctx.list_price)}, no haircut — if the "
+        f'"I can pay full asking — {fmt_money_precise(ctx.list_price)}, no haircut — if the '
         f"seller is open to carrying {fmt_money_precise(chosen_second)} of that as a second "
         f"mortgage at 0% interest with a {DEFAULT_BALLOON_YEARS}-year balloon. Bank takes the "
         "first, seller takes the second, and in "
         f"{DEFAULT_BALLOON_YEARS} years I refinance and the seller gets a single check for "
-        f"{fmt_money_precise(chosen_second)}.\"\n\n"
+        f'{fmt_money_precise(chosen_second)}."\n\n'
         "WHAT'S IN IT FOR THE SELLER (lead with this if there's hesitation)\n"
         "1. They get their number. The headline price is preserved — important for ego, taxes, "
         "and the comp record in the neighborhood.\n"
@@ -116,27 +116,27 @@ def solve(ctx: StructureContext) -> DealStructure | None:
         "WHY YOU NEED IT (be honest)\n"
         "\"At full asking with a single bank loan, the property doesn't cash-flow. Your "
         "willingness to carry a portion is what makes this deal possible. Without it, my best "
-        "offer drops 10-15% below ask and I close in cash — which one nets you more?\"\n\n"
+        'offer drops 10-15% below ask and I close in cash — which one nets you more?"\n\n'
         "ANTICIPATE OBJECTIONS\n"
-        "\u2022 \"Why 0%?\" \u2192 \"0% keeps the structure simple and stays inside IRS imputed-"
+        '\u2022 "Why 0%?" \u2192 "0% keeps the structure simple and stays inside IRS imputed-'
         "interest safe harbor for owner-financed sales. I'm open to a small rate if it makes you "
         "more comfortable — let's discuss.\"\n"
-        f"\u2022 \"What if you don't refinance in {DEFAULT_BALLOON_YEARS} years?\" \u2192 \"Then "
+        f'\u2022 "What if you don\'t refinance in {DEFAULT_BALLOON_YEARS} years?" \u2192 "Then '
         "I sell or pay you off from another source. Your note is recorded against the property in "
         "second position, behind the bank — meaning if I default, you can foreclose just like the "
-        "bank could. Equity in the property protects you.\"\n"
-        "\u2022 \"Why would I carry?\" \u2192 \"Because you get your full price. A typical "
+        'bank could. Equity in the property protects you."\n'
+        '\u2022 "Why would I carry?" \u2192 "Because you get your full price. A typical '
         "investor offer is 10-20% below ask in cash. Yours is full ask, and you become a secured "
-        "lender on a property you know inside and out.\"\n"
-        "\u2022 \"What if I want all cash?\" \u2192 \"Then this isn't your deal. But if a portion "
-        "as a secured note works, we both get what we want.\"\n\n"
+        'lender on a property you know inside and out."\n'
+        '\u2022 "What if I want all cash?" \u2192 "Then this isn\'t your deal. But if a portion '
+        'as a secured note works, we both get what we want."\n\n'
         "TRIAL CLOSE — soft, optional\n"
         "\"Would the seller be open to a creative offer like this? I'll have a creative-finance "
         "attorney draft the note so we're both protected — clean paper, recorded properly.\"\n\n"
         "TACTICS\n"
         "\u2022 Always offer FULL PRICE when asking for terms. Never ask for both at once.\n"
-        "\u2022 Use the words \"creative offer\" early — they signal an unusual structure is coming so the agent isn't blindsided.\n"
-        "\u2022 Have a creative-finance attorney lined up before you pitch. \"My attorney will paper this\" instantly raises trust.\n"
+        '\u2022 Use the words "creative offer" early — they signal an unusual structure is coming so the agent isn\'t blindsided.\n'
+        '\u2022 Have a creative-finance attorney lined up before you pitch. "My attorney will paper this" instantly raises trust.\n'
         f"\u2022 The {DEFAULT_BALLOON_YEARS}-year balloon is non-negotiable on your side — shorter and you can't refi cleanly, longer and the seller balks.\n"
         "\u2022 If they say no to 0%, counter with 2-3% — still cheaper than a HELOC and gives the seller something to feel good about."
     )
@@ -148,15 +148,9 @@ def solve(ctx: StructureContext) -> DealStructure | None:
 
     dom = ctx.days_on_market or 0
     if dom > 60:
-        sel_reason = (
-            f"The property has been listed {dom} days. "
-            "Seller's price flexibility is more likely."
-        )
+        sel_reason = f"The property has been listed {dom} days. Seller's price flexibility is more likely."
     else:
-        sel_reason = (
-            "The seller's personal and financial situation will indicate "
-            "if price flexibility is more likely."
-        )
+        sel_reason = "The seller's personal and financial situation will indicate if price flexibility is more likely."
 
     return DealStructure(
         id=ID,
@@ -167,10 +161,9 @@ def solve(ctx: StructureContext) -> DealStructure | None:
         # Math-carrying bullets — full breakdown in three lines so the card
         # tells the whole story without a separate lever block.
         bullets=[
-            f"Offer price:\u00A0{fmt_money(ctx.list_price)} → {fmt_money(new_price)}",
-            f"1st mortgage:\u00A0{fmt_money(bank_loan)} → "
-            f"{fmt_money(new_bank_loan)} @ {ctx.interest_rate * 100:.1f}%",
-            f"Seller 2nd:\u00A0{fmt_money(chosen_second)} (0%, {DEFAULT_BALLOON_YEARS}yr balloon)",
+            f"Offer price:\u00a0{fmt_money(ctx.list_price)} → {fmt_money(new_price)}",
+            f"1st mortgage:\u00a0{fmt_money(bank_loan)} → {fmt_money(new_bank_loan)} @ {ctx.interest_rate * 100:.1f}%",
+            f"Seller 2nd:\u00a0{fmt_money(chosen_second)} (0%, {DEFAULT_BALLOON_YEARS}yr balloon)",
         ],
         summary=(
             f"Saves {fmt_monthly(monthly_savings)}. Seller gets their price plus "

--- a/backend/app/services/deal_structures/templates/sub2.py
+++ b/backend/app/services/deal_structures/templates/sub2.py
@@ -75,15 +75,15 @@ def _build_sub2_pitch(
         "don't understand Sub2 and will discourage the seller from considering it. If the property "
         "is FSBO or off-market, even better.\n\n"
         "PREP — TWO QUESTIONS YOU MUST ASK FIRST\n"
-        "1. \"Do you have a mortgage on the property, and is the rate fixed?\" (Confirms the loan exists and is assumable in spirit.)\n"
-        "2. \"On closing day, do you need to walk away with a big check, or is debt relief and a clean exit more important?\"\n"
+        '1. "Do you have a mortgage on the property, and is the rate fixed?" (Confirms the loan exists and is assumable in spirit.)\n'
+        '2. "On closing day, do you need to walk away with a big check, or is debt relief and a clean exit more important?"\n'
         "   If they need a big cash check, Sub2 doesn't fit — pivot to a seller-second instead.\n\n"
         f"{confidence_line}\n\n"
         "THE OPEN — emotional discovery (Brent Daniels TTP style)\n"
         "Don't lead with the structure. Lead with their situation:\n"
         "\"Before I throw a number out, I want to understand what's going on. What's pushing the "
         "sale, and what would success look like for you on closing day? Are you trying to relocate, "
-        "downsize, get out from under the payment, or something else entirely?\"\n\n"
+        'downsize, get out from under the payment, or something else entirely?"\n\n'
         "(Listen for pain. Sub2 sells itself when you've heard the pain.)\n\n"
         "THE PITCH\n"
         "\"Here's a way I can help you that a normal buyer can't. I'd take over the existing "
@@ -106,25 +106,25 @@ def _build_sub2_pitch(
         "anyway: we put the property in a land trust before transfer (which doesn't trigger the "
         "clause), the bank receives the same payment from the same servicer it always has, and we "
         "set up a third-party servicing company so payments are documented. If I miss a payment, "
-        "you can take the property back. We both have an attorney review the docs.\"\n\n"
+        'you can take the property back. We both have an attorney review the docs."\n\n'
         "ANTICIPATE OBJECTIONS\n"
-        "\u2022 \"What if you stop paying?\" \u2192 \"You'd reclaim the property through the trust "
-        "agreement and any payments I made stay with you. The downside risk to you is small.\"\n"
-        "\u2022 \"What about the loan being in my name?\" \u2192 \"It stays on your credit report "
+        '\u2022 "What if you stop paying?" \u2192 "You\'d reclaim the property through the trust '
+        'agreement and any payments I made stay with you. The downside risk to you is small."\n'
+        '\u2022 "What about the loan being in my name?" \u2192 "It stays on your credit report '
         "as a mortgage in good standing — that's actually positive for your credit. I have on-time "
-        "payments documented through a third-party servicer.\"\n"
-        "\u2022 \"How long until the loan is paid off / refinanced?\" \u2192 \"My plan is to refinance "
+        'payments documented through a third-party servicer."\n'
+        '\u2022 "How long until the loan is paid off / refinanced?" \u2192 "My plan is to refinance '
         "in 5-7 years when rates come down or the property cash-flows enough to qualify. We can "
-        "agree to a maximum hold period in writing.\"\n\n"
+        'agree to a maximum hold period in writing."\n\n'
         "THE ASK — soft yes/no\n"
         "\"Would you be open to walking through what this would look like on paper? I'll have my "
         "creative-finance attorney draft the agreement so we both know we're protected. No "
         "commitment from you until you've seen the structure and your attorney has signed off.\"\n\n"
         "TRIAL CLOSE\n"
-        "\"What questions do you have about how this works for you?\"\n\n"
+        '"What questions do you have about how this works for you?"\n\n'
         "TACTICS\n"
         "\u2022 NEVER pitch Sub2 in the first 60 seconds. Build rapport, hear the pain, then offer the solution.\n"
-        "\u2022 Use \"would you be open to...\" framing — soft yes/no that doesn't trigger defensiveness (Pace Morby).\n"
+        '\u2022 Use "would you be open to..." framing — soft yes/no that doesn\'t trigger defensiveness (Pace Morby).\n'
         "\u2022 Always reference an attorney. Sellers fear creative deals less when professional paper is involved.\n"
         "\u2022 Pace Morby's rule: \"If they hesitate, ask 'what part doesn't sit right?' — then handle THAT specific objection.\"\n"
         "\u2022 Use a third-party loan servicer (e.g., Note Servicing Center). Documentation is your protection AND the seller's."

--- a/backend/app/services/house_hack_exporter.py
+++ b/backend/app/services/house_hack_exporter.py
@@ -25,7 +25,6 @@ from openpyxl.styles import (
 from openpyxl.utils import get_column_letter
 
 from app.core.defaults import OPERATING
-
 from app.schemas.proforma import FinancialProforma
 
 # ── Style tokens ─────────────────────────────────────────────────────────────
@@ -149,9 +148,7 @@ class HouseHackExcelExporter:
         self.d.expenses.insurance / 12 if self.d.expenses else 0
         # Simpler: calculate from known values
         taxes_annual = self.d.expenses.property_taxes if self.d.expenses else purchase * 0.012
-        insurance_annual = (
-            self.d.expenses.insurance if self.d.expenses else purchase * OPERATING.insurance_pct
-        )
+        insurance_annual = self.d.expenses.insurance if self.d.expenses else purchase * OPERATING.insurance_pct
 
         rows = [
             ("Loan Amount", loan, _CUR),

--- a/backend/app/services/iq_verdict_service.py
+++ b/backend/app/services/iq_verdict_service.py
@@ -227,15 +227,7 @@ def _calculate_str_strategy(
     maintenance = annual_revenue * o.maintenance_pct
     capex = annual_revenue * o.capex_pct
     op_ex = (
-        property_taxes
-        + insurance
-        + mgmt_fee
-        + platform_fees
-        + utilities
-        + supplies
-        + maintenance
-        + capex
-        + hoa_annual
+        property_taxes + insurance + mgmt_fee + platform_fees + utilities + supplies + maintenance + capex + hoa_annual
     )
     noi = annual_revenue - op_ex
     annual_cash_flow = noi - annual_debt

--- a/backend/app/services/notification_jobs.py
+++ b/backend/app/services/notification_jobs.py
@@ -29,9 +29,7 @@ logger = logging.getLogger(__name__)
 def _format_message(overdue: int, properties: int) -> tuple[str, str]:
     """Title + body for the digest push."""
     title = f"{overdue} overdue task{'s' if overdue != 1 else ''}"
-    body = (
-        f"Across {properties} propert{'ies' if properties != 1 else 'y'} in your pipeline"
-    )
+    body = f"Across {properties} propert{'ies' if properties != 1 else 'y'} in your pipeline"
     return title, body
 
 

--- a/backend/app/services/proforma_generator.py
+++ b/backend/app/services/proforma_generator.py
@@ -995,11 +995,7 @@ async def generate_proforma_data(
     vacancy_rate = _OPS.vacancy_rate * 100  # Convert to percent
     management_pct = _OPS.property_management_pct
     maintenance_pct = _OPS.maintenance_pct
-    insurance = (
-        insurance_override
-        if insurance_override is not None
-        else (purchase_price * _OPS.insurance_pct)
-    )
+    insurance = insurance_override if insurance_override is not None else (purchase_price * _OPS.insurance_pct)
     utilities = _OPS.utilities_monthly * 12
     landscaping = _OPS.landscaping_annual
     pest_control = _OPS.pest_control_annual

--- a/backend/app/services/property_service.py
+++ b/backend/app/services/property_service.py
@@ -483,7 +483,9 @@ class PropertyService:
                 )
                 market_cached = cached_data.get("market") or {}
                 missing_insurance = market_cached.get("insurance_annual") is None
-                legacy_valuation_formula = cached_data.get("valuation_formula_version") != _PROPERTY_CACHE_FORMULA_VERSION
+                legacy_valuation_formula = (
+                    cached_data.get("valuation_formula_version") != _PROPERTY_CACHE_FORMULA_VERSION
+                )
                 # HOA / condo / co-op fees are mandatory for property types
                 # where they almost always apply (Condo, Townhouse, Co-op,
                 # Multi-Family). Cached entries pre-dating the AXESSO HOA
@@ -492,9 +494,7 @@ class PropertyService:
                 # Property pages — re-fetch so `monthlyHoaFee` is captured.
                 details_cached = cached_data.get("details") or {}
                 ptype = str(details_cached.get("property_type") or "").lower()
-                hoa_likely = any(
-                    tok in ptype for tok in ("condo", "town", "co-op", "coop", "multi", "apartment")
-                )
+                hoa_likely = any(tok in ptype for tok in ("condo", "town", "co-op", "coop", "multi", "apartment"))
                 missing_hoa = hoa_likely and market_cached.get("hoa_fees_monthly") in (None, 0)
                 # Zillow data completely absent — AXESSO likely had a transient
                 # failure.  Re-fetch after 4 hours to give the API time to
@@ -1441,7 +1441,9 @@ class PropertyService:
 
                 # RentCast lotSize is in square feet; expose units explicitly.
                 lot_size_sqft = comp.get("lotSize")
-                lot_area_units = "Square Feet" if isinstance(lot_size_sqft, (int, float)) and lot_size_sqft > 0 else None
+                lot_area_units = (
+                    "Square Feet" if isinstance(lot_size_sqft, (int, float)) and lot_size_sqft > 0 else None
+                )
 
                 normalized_comps.append(
                     {
@@ -1644,7 +1646,9 @@ class PropertyService:
                 # transformer doesn't treat 21,344 sqft as 21,344 acres (which yields
                 # appraisal adjustments in the hundreds of millions).
                 lot_size_sqft = comp.get("lotSize")
-                lot_area_units = "Square Feet" if isinstance(lot_size_sqft, (int, float)) and lot_size_sqft > 0 else None
+                lot_area_units = (
+                    "Square Feet" if isinstance(lot_size_sqft, (int, float)) and lot_size_sqft > 0 else None
+                )
 
                 normalized_comps.append(
                     {

--- a/backend/app/services/receipt_parser_service.py
+++ b/backend/app/services/receipt_parser_service.py
@@ -59,13 +59,13 @@ _PROMPT = (
     "You are extracting structured data from a single receipt or invoice image.\n"
     "Return ONLY a JSON object with these keys (use null when unsure):\n"
     "  vendor: string — merchant name as printed on the receipt\n"
-    "  amount: string — total paid, just the number (e.g. \"127.45\"). Prefer the "
+    '  amount: string — total paid, just the number (e.g. "127.45"). Prefer the '
     "grand total over subtotals. No currency symbols, no thousands separators.\n"
     "  spent_on: string in YYYY-MM-DD format — transaction date\n"
     "  suggested_line_id: string — best match from the AVAILABLE LINES list "
     "below, or null if nothing fits well\n"
     "  description: string — short summary of what was purchased (e.g. "
-    "\"Drywall and joint compound\"). Keep under 80 chars.\n"
+    '"Drywall and joint compound"). Keep under 80 chars.\n'
     "Do not include commentary or markdown — JSON only."
 )
 
@@ -87,10 +87,13 @@ class ReceiptParserService:
 
         # Build the line-context block. The model picks ``suggested_line_id``
         # from this list; an empty list means we just don't suggest a line.
-        lines_block = "\n".join(
-            f"- {line['id']}: {line['label']} (category {line.get('category_id', '?')})"
-            for line in (available_lines or [])
-        ) or "(none)"
+        lines_block = (
+            "\n".join(
+                f"- {line['id']}: {line['label']} (category {line.get('category_id', '?')})"
+                for line in (available_lines or [])
+            )
+            or "(none)"
+        )
 
         # Choose content shape based on mime type.
         if mime_type in _IMAGE_MIME_TYPES:
@@ -143,9 +146,7 @@ class ReceiptParserService:
         return _parse_model_output(text, available_lines or [])
 
 
-def _parse_model_output(
-    raw: str, available_lines: list[dict[str, Any]]
-) -> dict[str, Any] | None:
+def _parse_model_output(raw: str, available_lines: list[dict[str, Any]]) -> dict[str, Any] | None:
     """Parse Claude's response into the ParsedReceipt-shaped dict.
 
     Defensive against models that wrap JSON in code fences or trailing prose.
@@ -215,9 +216,7 @@ def _safe_date(value: Any) -> date | None:
         return None
 
 
-def _validate_line_id(
-    value: Any, available_lines: list[dict[str, Any]]
-) -> str | None:
+def _validate_line_id(value: Any, available_lines: list[dict[str, Any]]) -> str | None:
     """Only return the suggested id if it actually appears in the supplied
     list — guard against the model hallucinating IDs."""
     if not isinstance(value, str) or not available_lines:

--- a/backend/app/services/rehab_intelligence.py
+++ b/backend/app/services/rehab_intelligence.py
@@ -15,11 +15,11 @@ Updated for 2025 South Florida construction costs.
 
 import logging
 from dataclasses import dataclass, field
-
-from app.core.defaults import OPERATING
 from datetime import datetime
 from enum import StrEnum
 from typing import Any
+
+from app.core.defaults import OPERATING
 
 logger = logging.getLogger(__name__)
 

--- a/backend/app/services/saved_property_service.py
+++ b/backend/app/services/saved_property_service.py
@@ -403,7 +403,9 @@ class SavedPropertyService:
 
         # Detect status change so we can stamp status_changed_at exactly when
         # it actually moves — model defaults only fire on insert, not update.
-        status_did_change = "status" in update_data and update_data["status"] is not None and update_data["status"] != previous_status
+        status_did_change = (
+            "status" in update_data and update_data["status"] is not None and update_data["status"] != previous_status
+        )
 
         for field, value in update_data.items():
             # Handle DealMakerRecord conversion to dict
@@ -442,6 +444,7 @@ class SavedPropertyService:
         # between saved_property_service and task_service.
         if status_did_change:
             from app.services.task_service import task_service as _ts
+
             try:
                 await _ts.seed_for_property(db, property_id, user_id)
             except Exception as e:
@@ -550,6 +553,7 @@ class SavedPropertyService:
         # Stabilized, Setup, etc.). Same dedup behavior as the status-change
         # path above.
         from app.services.task_service import task_service as _ts
+
         try:
             await _ts.seed_for_property(db, property_id, user_id)
         except Exception as e:

--- a/backend/app/services/task_service.py
+++ b/backend/app/services/task_service.py
@@ -15,9 +15,7 @@ from app.services.task_templates import template_for, template_label_for
 
 
 class TaskService:
-    async def _ensure_owns_property(
-        self, db: AsyncSession, property_id: str, user_id: str
-    ) -> SavedProperty | None:
+    async def _ensure_owns_property(self, db: AsyncSession, property_id: str, user_id: str) -> SavedProperty | None:
         """Return the property if ``user_id`` owns it, else None."""
         result = await db.execute(
             select(SavedProperty).where(
@@ -27,9 +25,7 @@ class TaskService:
         )
         return result.scalar_one_or_none()
 
-    async def list_for_property(
-        self, db: AsyncSession, property_id: str, user_id: str
-    ) -> list[PropertyTask] | None:
+    async def list_for_property(self, db: AsyncSession, property_id: str, user_id: str) -> list[PropertyTask] | None:
         """Return tasks for a property, or None if the user doesn't own it."""
         if not await self._ensure_owns_property(db, property_id, user_id):
             return None
@@ -45,9 +41,7 @@ class TaskService:
         )
         return list(result.scalars().all())
 
-    async def create(
-        self, db: AsyncSession, property_id: str, user_id: str, data: TaskCreate
-    ) -> PropertyTask | None:
+    async def create(self, db: AsyncSession, property_id: str, user_id: str, data: TaskCreate) -> PropertyTask | None:
         if not await self._ensure_owns_property(db, property_id, user_id):
             return None
         # Default sort_order = max(existing) + 1 so new tasks land at the bottom
@@ -73,9 +67,7 @@ class TaskService:
         await db.refresh(task)
         return task
 
-    async def update(
-        self, db: AsyncSession, task_id: str, user_id: str, data: TaskUpdate
-    ) -> PropertyTask | None:
+    async def update(self, db: AsyncSession, task_id: str, user_id: str, data: TaskUpdate) -> PropertyTask | None:
         # Single query: fetch task and verify ownership via the join condition.
         result = await db.execute(
             select(PropertyTask)
@@ -133,9 +125,7 @@ class TaskService:
         await db.commit()
         return True
 
-    async def seed_for_property(
-        self, db: AsyncSession, property_id: str, user_id: str
-    ) -> list[PropertyTask] | None:
+    async def seed_for_property(self, db: AsyncSession, property_id: str, user_id: str) -> list[PropertyTask] | None:
         """Create stage-templated tasks for the property's current state.
 
         Idempotent in spirit: skips template items whose title already exists
@@ -153,17 +143,13 @@ class TaskService:
 
         # Pull existing titles to dedupe — single round-trip.
         existing = await db.execute(
-            select(PropertyTask.title).where(
-                PropertyTask.saved_property_id == uuid.UUID(property_id)
-            )
+            select(PropertyTask.title).where(PropertyTask.saved_property_id == uuid.UUID(property_id))
         )
         existing_titles_lower = {t.strip().lower() for (t,) in existing.all()}
 
         # Pick a starting sort_order beyond any existing tasks.
         current_max = await db.scalar(
-            select(func.max(PropertyTask.sort_order)).where(
-                PropertyTask.saved_property_id == uuid.UUID(property_id)
-            )
+            select(func.max(PropertyTask.sort_order)).where(PropertyTask.saved_property_id == uuid.UUID(property_id))
         )
         next_order = (current_max or 0) + 1
 
@@ -300,9 +286,7 @@ class TaskService:
             )
         return out
 
-    async def summary_for_property(
-        self, db: AsyncSession, property_id: str, user_id: str
-    ) -> dict[str, int] | None:
+    async def summary_for_property(self, db: AsyncSession, property_id: str, user_id: str) -> dict[str, int] | None:
         """Return {total, open, overdue} counts in a single round-trip."""
         if not await self._ensure_owns_property(db, property_id, user_id):
             return None

--- a/backend/app/services/task_templates.py
+++ b/backend/app/services/task_templates.py
@@ -20,7 +20,6 @@ from __future__ import annotations
 
 from app.models.saved_property import FlipStage, PropertyStatus, SavedProperty
 
-
 # Each template item is (title, notes, due_offset_days). Notes are reserved
 # for non-obvious clarifications. due_offset_days is the number of days from
 # stage-entry the user should plan to finish the task — we set it only where
@@ -75,7 +74,8 @@ _OWNED_BASE_TEMPLATE: list[TaskTemplateItem] = [
 
 _OWNED_TEMPLATES: dict[str, list[TaskTemplateItem]] = {
     # Flip — Rehab is the entry stage; the first-time-owned base tasks fold in.
-    f"flip_{FlipStage.REHAB.value.lower()}": _OWNED_BASE_TEMPLATE + [
+    f"flip_{FlipStage.REHAB.value.lower()}": [
+        *_OWNED_BASE_TEMPLATE,
         ("Get 3 contractor bids", None, 7),
         ("Pull permits if required", None, 14),
         ("Order materials", None, 14),
@@ -88,7 +88,8 @@ _OWNED_TEMPLATES: dict[str, list[TaskTemplateItem]] = {
         ("Review price vs. market every week", None, 7),
     ],
     # BRRRR — diverges from flip after rehab.
-    f"brrrr_{FlipStage.REHAB.value.lower()}": _OWNED_BASE_TEMPLATE + [
+    f"brrrr_{FlipStage.REHAB.value.lower()}": [
+        *_OWNED_BASE_TEMPLATE,
         ("Get 3 contractor bids", None, 7),
         ("Pull permits if required", None, 14),
         ("Track rehab spend against estimator", None, 7),
@@ -105,7 +106,8 @@ _OWNED_TEMPLATES: dict[str, list[TaskTemplateItem]] = {
         ("Set up DSCR-loan payment auto-pay", None, 30),
     ],
     # Long-term rental — Rehab is now the entry stage; Make Ready follows.
-    f"ltr_{FlipStage.REHAB.value.lower()}": _OWNED_BASE_TEMPLATE + [
+    f"ltr_{FlipStage.REHAB.value.lower()}": [
+        *_OWNED_BASE_TEMPLATE,
         ("Get 3 contractor bids", None, 7),
         ("Pull permits if required", None, 14),
         ("Choose tenant-grade durable finishes", None, 14),
@@ -123,7 +125,8 @@ _OWNED_TEMPLATES: dict[str, list[TaskTemplateItem]] = {
         ("Set up rent collection (auto-pay if possible)", None, 7),
     ],
     # Short-term rental — Rehab is the entry stage; Setup follows.
-    f"str_{FlipStage.REHAB.value.lower()}": _OWNED_BASE_TEMPLATE + [
+    f"str_{FlipStage.REHAB.value.lower()}": [
+        *_OWNED_BASE_TEMPLATE,
         ("Get 3 contractor bids", None, 7),
         ("Pull permits if required", None, 14),
         ("Plan rehab around guest experience (lighting, comfort, photos)", None, 14),
@@ -142,7 +145,8 @@ _OWNED_TEMPLATES: dict[str, list[TaskTemplateItem]] = {
         ("Track occupancy + ADR weekly", None, 7),
     ],
     # House Hack — same shape as LTR but with owner-occupancy considerations.
-    f"house_hack_{FlipStage.REHAB.value.lower()}": _OWNED_BASE_TEMPLATE + [
+    f"house_hack_{FlipStage.REHAB.value.lower()}": [
+        *_OWNED_BASE_TEMPLATE,
         ("Get 3 contractor bids", None, 7),
         ("Pull permits if required", None, 14),
         ("Plan owner-unit + rental-unit improvements", None, 14),
@@ -160,7 +164,8 @@ _OWNED_TEMPLATES: dict[str, list[TaskTemplateItem]] = {
         ("Set up rent collection (auto-pay if possible)", None, 14),
     ],
     # Wholesale — minimal-cleanup quick exit (a.k.a. wholetail).
-    f"wholesale_{FlipStage.REHAB.value.lower()}": _OWNED_BASE_TEMPLATE + [
+    f"wholesale_{FlipStage.REHAB.value.lower()}": [
+        *_OWNED_BASE_TEMPLATE,
         ("Identify minimum-viable cleanup scope", None, 7),
         ("Get a quick contractor quote", None, 7),
         ("Set target list price + timeline", None, 14),

--- a/backend/app/services/timeline_service.py
+++ b/backend/app/services/timeline_service.py
@@ -15,7 +15,6 @@ User-authored notes are stored as ``PropertyAdjustment`` rows with
 from __future__ import annotations
 
 import uuid
-from datetime import datetime
 from typing import Any, Literal
 
 from sqlalchemy import select
@@ -26,7 +25,6 @@ from app.models.contact import PropertyContact
 from app.models.document import Document
 from app.models.saved_property import PropertyAdjustment, SavedProperty
 from app.models.task import PropertyTask
-
 
 TimelineEventKind = Literal[
     "status_change",
@@ -59,9 +57,7 @@ def _humanize_status_change(prev: Any, new: Any) -> str:
 
 
 class TimelineService:
-    async def _ensure_owns_property(
-        self, db: AsyncSession, property_id: str, user_id: str
-    ) -> SavedProperty | None:
+    async def _ensure_owns_property(self, db: AsyncSession, property_id: str, user_id: str) -> SavedProperty | None:
         result = await db.execute(
             select(SavedProperty).where(
                 SavedProperty.id == uuid.UUID(property_id),
@@ -88,13 +84,17 @@ class TimelineService:
 
         # 1) PropertyAdjustment — status / flip_stage / generic notes.
         adj_rows = (
-            await db.execute(
-                select(PropertyAdjustment)
-                .where(PropertyAdjustment.property_id == prop_uuid)
-                .order_by(PropertyAdjustment.created_at.desc())
-                .limit(limit)
+            (
+                await db.execute(
+                    select(PropertyAdjustment)
+                    .where(PropertyAdjustment.property_id == prop_uuid)
+                    .order_by(PropertyAdjustment.created_at.desc())
+                    .limit(limit)
+                )
             )
-        ).scalars().all()
+            .scalars()
+            .all()
+        )
         for a in adj_rows:
             kind, title, body = self._classify_adjustment(a)
             if kind is None:
@@ -116,13 +116,17 @@ class TimelineService:
 
         # 2) PropertyTask — added (creation) and completed/reopened (state).
         task_rows = (
-            await db.execute(
-                select(PropertyTask)
-                .where(PropertyTask.saved_property_id == prop_uuid)
-                .order_by(PropertyTask.created_at.desc())
-                .limit(limit)
+            (
+                await db.execute(
+                    select(PropertyTask)
+                    .where(PropertyTask.saved_property_id == prop_uuid)
+                    .order_by(PropertyTask.created_at.desc())
+                    .limit(limit)
+                )
             )
-        ).scalars().all()
+            .scalars()
+            .all()
+        )
         for t in task_rows:
             events.append(
                 {
@@ -148,14 +152,18 @@ class TimelineService:
 
         # 3) BudgetExpense — actual spend logged.
         exp_rows = (
-            await db.execute(
-                select(BudgetExpense)
-                .join(RehabBudget, RehabBudget.id == BudgetExpense.budget_id)
-                .where(RehabBudget.saved_property_id == prop_uuid)
-                .order_by(BudgetExpense.created_at.desc())
-                .limit(limit)
+            (
+                await db.execute(
+                    select(BudgetExpense)
+                    .join(RehabBudget, RehabBudget.id == BudgetExpense.budget_id)
+                    .where(RehabBudget.saved_property_id == prop_uuid)
+                    .order_by(BudgetExpense.created_at.desc())
+                    .limit(limit)
+                )
             )
-        ).scalars().all()
+            .scalars()
+            .all()
+        )
         for ex in exp_rows:
             vendor = ex.vendor or "no vendor"
             events.append(
@@ -176,13 +184,17 @@ class TimelineService:
 
         # 4) PropertyContact — only "added" surfaces; updates are too noisy.
         contact_rows = (
-            await db.execute(
-                select(PropertyContact)
-                .where(PropertyContact.saved_property_id == prop_uuid)
-                .order_by(PropertyContact.created_at.desc())
-                .limit(limit)
+            (
+                await db.execute(
+                    select(PropertyContact)
+                    .where(PropertyContact.saved_property_id == prop_uuid)
+                    .order_by(PropertyContact.created_at.desc())
+                    .limit(limit)
+                )
             )
-        ).scalars().all()
+            .scalars()
+            .all()
+        )
         for c in contact_rows:
             role_label = c.role.value.replace("_", " ").title() if c.role else "Contact"
             events.append(
@@ -202,19 +214,19 @@ class TimelineService:
         # 5) Document — uploaded files are deal-level events worth surfacing.
         try:
             doc_rows = (
-                await db.execute(
-                    select(Document)
-                    .where(Document.property_id == prop_uuid)
-                    .order_by(Document.uploaded_at.desc())
-                    .limit(limit)
+                (
+                    await db.execute(
+                        select(Document)
+                        .where(Document.property_id == prop_uuid)
+                        .order_by(Document.uploaded_at.desc())
+                        .limit(limit)
+                    )
                 )
-            ).scalars().all()
+                .scalars()
+                .all()
+            )
             for d in doc_rows:
-                doc_type_label = (
-                    d.document_type.value.replace("_", " ").title()
-                    if d.document_type
-                    else "Document"
-                )
+                doc_type_label = d.document_type.value.replace("_", " ").title() if d.document_type else "Document"
                 events.append(
                     {
                         "id": f"doc:{d.id}",
@@ -236,9 +248,7 @@ class TimelineService:
 
         # 6) RehabBudget.baseline_locked_at — single milestone.
         budget_row = (
-            await db.execute(
-                select(RehabBudget).where(RehabBudget.saved_property_id == prop_uuid)
-            )
+            await db.execute(select(RehabBudget).where(RehabBudget.saved_property_id == prop_uuid))
         ).scalar_one_or_none()
         if budget_row and budget_row.baseline_locked_at:
             events.append(
@@ -259,11 +269,8 @@ class TimelineService:
         events.sort(key=lambda e: e["occurred_at"], reverse=True)
         return events[:limit]
 
-    def _classify_adjustment(
-        self, a: PropertyAdjustment
-    ) -> tuple[TimelineEventKind | None, str, str | None]:
+    def _classify_adjustment(self, a: PropertyAdjustment) -> tuple[TimelineEventKind | None, str, str | None]:
         """Map a PropertyAdjustment row to (kind, title, body) or (None,...) to skip."""
-        kind: TimelineEventKind | None
         if a.adjustment_type == NOTE_ADJUSTMENT_TYPE:
             return ("note", a.reason or "Note", None)
         if a.adjustment_type == "status":

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -36,6 +36,7 @@ ignore = [
     "S105",  # possible hardcoded password (false positive for enum/constant names)
     "RUF012",  # mutable class attribute (fix incrementally)
     "RUF003",  # comment ambiguous unicode (fix incrementally)
+    "RUF002",  # docstring ambiguous unicode (× / − used intentionally in math docstrings)
     "S608",  # possible SQL injection (false positive: logging path in f-string)
 ]
 

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -89,12 +89,22 @@ apscheduler>=3.10,<4.0
 # ===========================================
 # Testing
 # ===========================================
-pytest==8.0.0
-pytest-asyncio==0.23.3
+# pytest-asyncio 0.23.3 + pytest 8.0.0 raise
+# `AttributeError: 'Package' object has no attribute 'obj'` at collection time.
+# Fixed in pytest-asyncio 0.24+; pytest 8.2+ is the matching baseline.
+pytest>=8.2,<9
+pytest-asyncio>=0.24,<1
 pytest-cov==4.1.0
 aiosqlite==0.19.0  # Async SQLite for testing
 testcontainers[postgres]>=4.0
 httpx==0.26.0      # TestClient async support
+
+# ===========================================
+# Lint (kept here so CI installs the same version we develop against;
+# the lint job currently does `pip install ruff` unpinned which causes
+# silent regressions on every ruff release).
+# ===========================================
+ruff==0.15.12
 
 # ===========================================
 # Load Testing (optional — install separately)


### PR DESCRIPTION
## Why

CI on `main` has been red for 50+ consecutive runs going back to at least May 10. Two open PRs (#48, #49) inherit the same red signal and cannot be evaluated on their own merits. This PR fixes the cleanly-fixable backend issues and **deliberately surfaces** a long-standing test-fixture bug that was being masked by an earlier crash.

## What this PR achieves

| Check | On `main` (before) | On this PR (after) |
|---|---|---|
| `lint` | FAIL — 45 ruff violations + 27 files needing `ruff format` | ✓ SUCCESS |
| `frontend-test` | SUCCESS | ✓ SUCCESS |
| `test` | FAIL — `INTERNALERROR AttributeError: 'Package' object has no attribute 'obj'`, **0 tests collected** | FAIL — but now collects 371 tests; reveals a pre-existing SQLite-UUID fixture bug (see below) |
| `frontend-build` | FAIL — `prettier --check` against 500 unformatted files | FAIL (unchanged — by design, separate prettier-sweep PR) |

## What changed

Two commits, both mechanical, no business logic touched.

### Commit 1 — `chore(ci): bump pytest-asyncio + pin ruff`

| File | Change |
|---|---|
| `backend/requirements.txt` | `pytest==8.0.0` → `pytest>=8.2,<9` · `pytest-asyncio==0.23.3` → `pytest-asyncio>=0.24,<1` · add `ruff==0.15.12` |
| `backend/pyproject.toml` | add `RUF002` to existing `ignore` list (sibling of existing `RUF003` ignore) |

`pytest 8.0.0` + `pytest-asyncio 0.23.3` is a known-broken pair: `pytest-asyncio.plugin.pytest_collectstart` calls `collector.obj`, but pytest 8.0 removed `Package.obj`. The fix is in `pytest-asyncio>=0.24`. The `lint` job's previously-unpinned `pip install ruff` is pinned to stop silent regressions on each ruff release. `RUF002` (ambiguous unicode in docstrings) flags the `×` and `−` characters in our math docstrings — those are intentional and more readable than the suggested ASCII substitutes.

### Commit 2 — `style(backend): apply ruff check --fix + ruff format sweep`

Three buckets, all mechanical:

1. **`ruff check --fix app/`** — 30 auto-fixed violations across ~12 files (UP037 quoted annotations, I001 import resorting, F401 unused imports, RUF100 stale `# noqa: ARG001` comments).
2. **Manual fixes (8 violations across 3 files):**
   - 6× RUF005 in `services/task_templates.py`: `_OWNED_BASE_TEMPLATE + [...]` → `[*_OWNED_BASE_TEMPLATE, ...]`. Multi-line shape preserved (`--unsafe-fix` would collapse them onto a single line, much harder to scan).
   - 1× F842 in `services/timeline_service.py`: drop the unused `kind: TimelineEventKind | None` annotation in `_classify_adjustment`. Every branch returns a tuple literal; `kind` is never assigned.
   - 1× RUF022 in `models/__init__.py`: sort `__all__` (ASCII order, so `ShareType` precedes `SharedLink`).
3. **`ruff format app/`** — 27 files. The lint job runs `ruff format --check` as a second step; that step was also red on `main`. Mostly collapses multi-line function calls that fit within the 120-char line limit. Pure whitespace.

## Honest accounting of the `test` job

This PR makes the `test` job **strictly better** but does not turn it green.

**Before:** pytest crashed during collection. Zero tests ever ran. Exit code 3. We had no idea what shape the actual test suite was in.

**After:** pytest collects 371 tests cleanly. Roughly half of them then **fail or error at runtime** with:

```
sqlalchemy.exc.CompileError: (in table 'roles', column 'id'):
Compiler <SQLiteTypeCompiler> can't render element of type UUID
```

This is **not** a regression introduced by this PR — it's pre-existing rot exposed by the collection now working. Several test files (e.g. `test_admin.py`, `test_auth_service.py`, `test_saved_properties.py`, `test_calculators.py`) use SQLite via `aiosqlite`, but the SQLAlchemy models declare native `UUID` columns that only Postgres can compile. This has been broken on `main` for at least the 50 most recent CI runs (May 10–14) — masked the entire time by the pytest-asyncio collection crash.

**Fixing it is a separate PR** (and a meatier one — likely needs a custom UUID `TypeDecorator` for SQLite, or a migration of all unit tests to use the Postgres testcontainer that's already in `requirements.txt`).

The `integration` and `pg`-suffixed tests that explicitly target Postgres should pass in CI; only the SQLite-fixture tests are erroring. Easy to verify by running `pytest tests/integration/` against the Postgres service.

## Verification (local)

Reproduced the exact CI environment using `backend/.venv` (pytest 8.0.0 / pytest-asyncio 0.23.3 / ruff 0.15.12). With the new pinned versions:

```
ruff check app          → All checks passed
ruff format --check app → 164 files already formatted
pytest --collect-only   → 371 tests collected (up from 0)
```

## Out of scope (intentional, follow-ups needed)

- **Fix SQLite-UUID test fixture rot** — needs its own PR; will fully turn the `test` job green.
- **Frontend `prettier --check` sweep** — 500 files; will land as `chore(frontend): apply prettier sweep` in a separate PR so PR #48's rebase timing stays under your control.
- **Alembic model drift** — flagged in CI as a non-blocking warning (`alembic check || echo "::warning::"`). Real but doesn't fail CI.
- **Vercel duplicate projects + Railway PR-preview env vars** — dashboard-level cleanup, no code change. (Two stale Vercel projects are stuck on "Canceled from the Vercel Dashboard"; Railway PR preview builds the image but fails at container start.)

## Risk

Low. Diff is dependency bumps and formatter output. No business logic touched, no API surface changed, no tests modified. The newly-revealed test failures are pre-existing — they exist on `main` today and would be visible the moment anyone fixed the collection crash by any other means.