### PR TITLE
fix(theme): allowlist V2 homepage + VideoModal in theme surface check

### DIFF
--- a/frontend/docs/theme-surface-exceptions.md
+++ b/frontend/docs/theme-surface-exceptions.md
@@ -15,6 +15,8 @@ These files **define** the tokens and are excluded from the check script:
 | `src/app/api/report/route.ts` | Server-side PDF generation (fixed colors required) |
 | `capacitor.config.ts` | Native splash screen configuration |
 | `src/__tests__/theme-surfaces.test.ts` | Test file that asserts against forbidden patterns |
+| `src/components/landing/DealGapIQHomepageV2.tsx` | Frozen legacy homepage variant — see "Intentional Non-Token Backgrounds" below |
+| `src/components/ui/VideoModal.tsx` | Video letterbox `#000` — see "Intentional Non-Token Backgrounds" below |
 
 ## Intentional Non-Token Backgrounds
 
@@ -25,6 +27,8 @@ These files **define** the tokens and are excluded from the check script:
 | `src/components/auth/RegisterForm.tsx` | `#103351`, `#15446c` | Auth form gradient accents (not container fills) |
 | `src/components/auth/ForgotPasswordForm.tsx` | `#103351`, `#15446c` | Auth form gradient accents (not container fills) |
 | `src/components/landing/landing.css` | `#060d17` | Landing page deep background (below --surface-base layer) |
+| `src/components/landing/DealGapIQHomepageV2.tsx` | `bg-black`, `border-[#1E2530]`, `border-[#14181F]` (~58 occurrences) | Frozen legacy homepage variant. V4 is production; V2 is reachable only via `?v=2` URL flag and exists as a rollback safety net. Hardcoded colors are intentional — visual fidelity must match what was last deployed so a rollback produces the expected look. Migrating to semantic tokens would shift the borders (e.g. `--border-default` is `#334155`, materially lighter than `#1E2530`). When V2 is no longer needed as a rollback target it should be deleted, not refactored. |
+| `src/components/ui/VideoModal.tsx` | `background: '#000'` on the 16:9 player container | Standard video-player letterbox. Videos sit on solid black regardless of theme so frame dimensions render predictably across content. Functionally equivalent to the "Overlays: rgba(0,0,0,0.x) for modal backdrops" exception listed in the workspace theme rule. |
 
 ## How to Add an Exception
 

--- a/frontend/scripts/check-theme-surfaces.sh
+++ b/frontend/scripts/check-theme-surfaces.sh
@@ -24,7 +24,7 @@ if [[ "${1:-}" == "--strict" ]]; then
   STRICT=true
 fi
 
-ALLOWLIST_PATTERN="globals\.css|semantic-tokens\.ts|verdict-design-tokens\.ts|api/report/route\.ts|capacitor\.config\.ts|theme-surfaces\.test\.ts"
+ALLOWLIST_PATTERN="globals\.css|semantic-tokens\.ts|verdict-design-tokens\.ts|api/report/route\.ts|capacitor\.config\.ts|theme-surfaces\.test\.ts|DealGapIQHomepageV2\.tsx|VideoModal\.tsx"
 
 VIOLATIONS=0
 VIOLATION_FILES=""


### PR DESCRIPTION
## Why

The `theme:check:strict` step in the `frontend-build` CI job has been failing on `main` the whole time, hidden behind the earlier `format:check` failure. With prettier sorted by PR #51, this is the next gate.

59 violations across 2 files, both pre-existing:

- `src/components/landing/DealGapIQHomepageV2.tsx` (58 hits — `bg-black`, `border-[#1E2530]`, `border-[#14181F]`)
- `src/components/ui/VideoModal.tsx` (1 hit — `background: '#000'` on the 16:9 player container)

## Why allowlist instead of refactor

Both are intentional edge cases that don't fit the *"page shell uses --surface-base, card uses --surface-card"* model. Documented as exceptions rather than refactored.

### `DealGapIQHomepageV2.tsx` — frozen rollback variant

V4 is the production homepage; V2 is reachable only via `?v=2` URL flag (per `app/page.tsx`'s `// V4 = marketing-tuned homepage. V3 and V2 remain available via query flags for rollback.`). It exists as a frozen rollback safety net.

Migrating to semantic tokens would shift V2's visual fidelity:

| V2 hardcoded | Closest semantic token | Pixel diff |
|---|---|---|
| `border-[#1E2530]` (rgb 30,37,48) | `--border-default` (`#334155` = rgb 51,65,85) | materially lighter |
| `bg-black` | `--surface-base` / `--surface-card` (`#000000` in dark) | identical in dark, light-mode would shift |

Defeating the purpose of keeping V2 around. The right exit is **delete V2** when it's no longer needed as a rollback target — not refactor it.

### `VideoModal.tsx` — letterbox

Standard video-player letterbox. The workspace theme rule already documents *"Overlays: rgba(0,0,0,0.x) for modal backdrops"* as an allowed exception; a 16:9 player container with solid `#000` is functionally the same case.

## What changed

- `frontend/scripts/check-theme-surfaces.sh`: extended `ALLOWLIST_PATTERN` with `DealGapIQHomepageV2\.tsx` and `VideoModal\.tsx`. Two-line change.
- `frontend/docs/theme-surface-exceptions.md`: added both files to the allowlist table with full rationale.

**No application code changed.**

## Verification (local)

```
npm run theme:check:strict  → Clean — no hardcoded dark backgrounds
npm run lint                → 0 errors (635 pre-existing warnings)
npx tsc --noEmit            → no errors
npm run build               → built successfully
```

## To make `frontend-build` fully green

This PR closes the `theme:check:strict` step. The earlier `format:check` step is closed by PR #51. Both PRs are independent — merge in either order.

| Step | This PR | + PR #51 |
|---|---|---|
| `lint` (eslint) | passes | passes |
| `format:check` | fails (500 files) | passes |
| `theme:check:strict` | passes | passes |
| `tsc --noEmit` | passes | passes |
| `next build` | passes | passes |

## Risk

Zero functional risk. Two-line allowlist update + documentation. No source code or styles touched.

Made with [Cursor](https://cursor.com)