### PR TITLE
fix(frontend): Phase 1 — critical bug fixes, security hardening, and CI guards

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,12 +50,51 @@ jobs:
         run: npm run theme:check:strict
         working-directory: frontend
 
+      # ────────────────────────────────────────────
+      # Source-side guard: forbid client-bundled
+      # references to third-party / privileged keys.
+      # If these env vars ever appear in src/, the
+      # `NEXT_PUBLIC_` prefix would inline them into
+      # the browser bundle (account takeover / quota
+      # abuse). Allow only test files.
+      # ────────────────────────────────────────────
+      - name: Forbid client-bundled secret env vars
+        run: |
+          set -e
+          PATTERN='NEXT_PUBLIC_(AXESSO|RENTCAST|ZILLOW|REDFIN|REALTOR|ADMIN|.*_SECRET|.*_PRIVATE_KEY|STRIPE_SECRET)'
+          if grep -RInE "$PATTERN" src/ \
+              --include='*.ts' --include='*.tsx' --include='*.js' --include='*.jsx' \
+              --exclude-dir='__tests__'; then
+            echo "::error::Forbidden NEXT_PUBLIC_* env reference found in src/. Move to backend or rename without the NEXT_PUBLIC_ prefix."
+            exit 1
+          fi
+          echo "✓ No forbidden NEXT_PUBLIC_* secret references in src/"
+        working-directory: frontend
+
       - name: TypeScript type check
         run: npx tsc --noEmit
         working-directory: frontend
 
       - name: Build
         run: npm run build
+        working-directory: frontend
+
+      # ────────────────────────────────────────────
+      # Bundle-side guard: scan the produced JS for
+      # forbidden env var names, in case a future
+      # change references them via a path the source
+      # grep above couldn't see (template strings,
+      # dynamic process.env access, etc.).
+      # ────────────────────────────────────────────
+      - name: Forbid forbidden env names in built bundle
+        run: |
+          set -e
+          if find .next/static -type f \( -name '*.js' -o -name '*.mjs' \) -print0 \
+              | xargs -0 grep -lE 'NEXT_PUBLIC_(AXESSO|RENTCAST|ZILLOW|REDFIN|REALTOR|ADMIN|.*_SECRET|.*_PRIVATE_KEY|STRIPE_SECRET)' 2>/dev/null; then
+            echo "::error::Forbidden NEXT_PUBLIC_* env name appears in built JS bundle."
+            exit 1
+          fi
+          echo "✓ No forbidden NEXT_PUBLIC_* env names in built bundle"
         working-directory: frontend
 
   # ────────────────────────────────────────────

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -48,13 +48,17 @@ if (!isCapacitor) {
     },
   ]
 
+  // NOTE: /compare is intentionally NOT redirected — it serves the
+  // saved-property side-by-side comparison UI (consumes ?ids=…) and
+  // is a different feature from /price-intel (single-address comps).
+  // A previous redirect to /price-intel?view=sale silently broke the
+  // comparison workflow because Price Intel ignores `ids`.
   nextConfig.redirects = async () => [
     { source: '/landing', destination: '/', permanent: true },
     { source: '/landing2', destination: '/', permanent: true },
     { source: '/verdict', destination: '/discovery', permanent: true },
     { source: '/analysis-iq', destination: '/discovery', permanent: true },
     { source: '/verdict-iq', destination: '/discovery', permanent: true },
-    { source: '/compare', destination: '/price-intel?view=sale', permanent: true },
     { source: '/rental-comps', destination: '/price-intel?view=rent', permanent: true },
   ]
 

--- a/frontend/src/app/api/report/route.ts
+++ b/frontend/src/app/api/report/route.ts
@@ -38,13 +38,41 @@ interface Proforma {
 }
 
 // ---------------------------------------------------------------------------
-// Formatting
+// Formatting / escaping
 // ---------------------------------------------------------------------------
 const fmt = (v: number, d = 0) => v.toLocaleString('en-US', { minimumFractionDigits: d, maximumFractionDigits: d })
 const $ = (v: number) => v >= 1_000_000 ? `$${(v/1_000_000).toFixed(2)}M` : `$${fmt(v)}`
 const pct = (v: number, d = 2) => `${v.toFixed(d)}%`
 const sign$ = (v: number) => v >= 0 ? $(v) : `-${$(Math.abs(v))}`
 const ptypeLabel = (t: string) => { const m: Record<string,string> = { 'single family':'single-family residence','singlefamily':'single-family residence','condo':'condominium','townhouse':'townhouse','duplex':'duplex' }; return m[t.toLowerCase()] || t.toLowerCase() }
+
+/**
+ * Escape a string for safe interpolation inside HTML text or attribute
+ * contexts. Used for every backend-supplied string that flows into the
+ * report HTML, since we intentionally do NOT trust upstream sanitization.
+ */
+function esc(v: string | number | null | undefined): string {
+  if (v == null) return ''
+  return String(v)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;')
+}
+
+/**
+ * Render a constrained subset of inline markdown ( **bold** ) safely:
+ * 1) escape the entire input first,
+ * 2) then promote the *escaped* `**…**` markers to `<strong>` tags.
+ * Any HTML-significant characters in the source can never produce real tags.
+ */
+function renderInlineMd(v: string | null | undefined): string {
+  if (!v) return ''
+  return esc(v)
+    .replace(/\*\*(.*?)\*\*/g, '<strong>$1</strong>')
+    .replace(/\n/g, ' ')
+}
 
 // ---------------------------------------------------------------------------
 // Theme palettes
@@ -78,8 +106,8 @@ function ring(score: number, grade: string, p: P, sz=160): string {
 // AI Narrative Engine (ported from Python pdf_narrative.py)
 // ---------------------------------------------------------------------------
 function narrativeCover(d: Proforma): string {
-  const pr = d.property, tp = ptypeLabel(pr.property_type), st = d.strategy_type.toUpperCase()
-  let t = `This comprehensive investment analysis provides detailed financial projections and property insights for a ${tp} located in ${pr.city}, ${pr.state}. `
+  const pr = d.property, tp = esc(ptypeLabel(pr.property_type)), st = esc(d.strategy_type.toUpperCase())
+  let t = `This comprehensive investment analysis provides detailed financial projections and property insights for a ${tp} located in ${esc(pr.city)}, ${esc(pr.state)}. `
   t += pr.year_built ? `Built in ${pr.year_built}, this property offers ` : 'This property offers '
   t += `${pr.bedrooms} bedrooms and ${pr.bathrooms} bathrooms across ${fmt(pr.square_feet)} square feet of living space`
   if (pr.lot_size > 0) { const ac = pr.lot_size / 43560; if (ac >= 0.1) t += ` on a ${fmt(pr.lot_size)}-square-foot lot (${ac.toFixed(2)} acres)` }
@@ -89,7 +117,7 @@ function narrativeCover(d: Proforma): string {
 function narrativeOverview(d: Proforma): string {
   const coc = d.metrics.cash_on_cash_return, pr = d.property, ac = d.acquisition, inc = d.income
   const assess = coc >= 8 ? 'a strong cash-flowing investment opportunity' : coc >= 0 ? 'a moderate investment opportunity with positive returns' : 'a wealth-building investment opportunity focused on long-term appreciation'
-  let t = `This ${ptypeLabel(pr.property_type)} represents ${assess} in ${pr.city}'s residential market. With a list price of ${$(ac.list_price)} and a projected monthly rent of ${$(inc.monthly_rent)}, the property `
+  let t = `This ${esc(ptypeLabel(pr.property_type))} represents ${assess} in ${esc(pr.city)}'s residential market. With a list price of ${$(ac.list_price)} and a projected monthly rent of ${$(inc.monthly_rent)}, the property `
   if (d.metrics.price_per_sqft > 0) t += `carries a price per square foot of $${fmt(d.metrics.price_per_sqft)}. `
   t += `The rent-to-price ratio and location fundamentals position this property for sustained investor interest.`
   return t
@@ -99,7 +127,7 @@ function narrativeFinancing(d: Proforma): string {
   const f = d.financing, ac = d.acquisition
   let t = `The investment requires a total acquisition cost of ${$(ac.total_acquisition_cost)}, including the purchase price and closing costs`
   if (ac.rehab_costs > 0) t += `, plus ${$(ac.rehab_costs)} in rehabilitation costs`
-  t += `. With a ${f.loan_type} financing structure utilizing a ${f.down_payment_percent.toFixed(0)}% down payment, investors can leverage ${$(f.loan_amount)} while maintaining strong equity positioning. `
+  t += `. With a ${esc(f.loan_type)} financing structure utilizing a ${f.down_payment_percent.toFixed(0)}% down payment, investors can leverage ${$(f.loan_amount)} while maintaining strong equity positioning. `
   t += `The ${f.loan_term_years}-year fixed mortgage at ${f.interest_rate.toFixed(2)}% interest provides payment stability throughout the hold period. Over the life of the loan, total interest payments will reach ${$(f.total_interest_over_life)}, making refinancing opportunities an important consideration.`
   return t
 }
@@ -146,7 +174,7 @@ function narrativeDealScore(d: Proforma): string {
   else if (ds.score >= 60) { assess = 'a moderate opportunity with upside potential'; action = 'Consider negotiating toward the breakeven price to improve returns.' }
   else if (ds.score >= 40) { assess = 'a marginal opportunity requiring careful evaluation'; action = 'Significant price negotiation would be needed to achieve target returns.' }
   else { assess = 'a challenging investment at current pricing'; action = 'The current pricing does not support the investment thesis. Look for substantial price reduction or alternative strategies.' }
-  let t = `The DealGapIQ Deal Score of ${ds.score} (${ds.grade}) indicates this is ${assess}. ${ds.verdict || ''}. `
+  let t = `The DealGapIQ Deal Score of ${ds.score} (${esc(ds.grade)}) indicates this is ${assess}. ${esc(ds.verdict || '')}. `
   const incomeVal = ds.income_value ?? ds.breakeven_price ?? 0
   if (incomeVal > 0 && ds.discount_required !== 0) t += `The income value is calculated at ${$(incomeVal)}, representing a ${Math.abs(ds.discount_required).toFixed(1)}% ${ds.discount_required > 0 ? 'discount' : 'premium'} from the current price. `
   return t + action
@@ -212,12 +240,17 @@ function buildReport(d: Proforma, theme: string, photos: string[]): string {
     return `<div class="sens-block"><h4>${title}</h4><table class="tbl"><thead><tr><th>Change</th><th>Value</th><th>IRR</th><th>CoC Return</th><th>Net Profit</th></tr></thead><tbody>${rows.map(s => { const c = s.irr>=0?p.pos:p.neg; return `<tr><td>${s.change_percent>0?'+':''}${pct(s.change_percent,0)}</td><td>${$(s.absolute_value)}</td><td style="color:${c}">${pct(s.irr)}</td><td style="color:${c}">${pct(s.cash_on_cash)}</td><td style="color:${c}">${sign$(s.net_profit)}</td></tr>` }).join('')}</tbody></table></div>`
   }
 
-  // Photo grid HTML
-  const photoHTML = ph.length > 0 ? `<div class="photos photos-${Math.min(ph.length,5)}">${ph.map((u,i) => `<div class="ph${i===0?' ph-main':''}"><img src="${u}" alt=""/></div>`).join('')}</div>` : ''
+  // Photo grid HTML — only allow http(s) URLs (defends against `javascript:` /
+  // `data:` URIs being smuggled through the photo provider) and escape into
+  // the attribute context.
+  const safePhotos = ph.filter((u) => typeof u === 'string' && /^https?:\/\//i.test(u))
+  const photoHTML = safePhotos.length > 0
+    ? `<div class="photos photos-${Math.min(safePhotos.length,5)}">${safePhotos.map((u,i) => `<div class="ph${i===0?' ph-main':''}"><img src="${esc(u)}" alt=""/></div>`).join('')}</div>`
+    : ''
 
   const N = 6
-  const pgHdr = `<div class="pg-hdr"><div class="logo-sm">DealGap<span class="iq">IQ</span></div><div class="pg-hdr-title">${d.property_address}</div></div>`
-  const pgFt = (n: number) => `<div class="pg-foot"><span>DealGapIQ Property Report</span><span>${dateStr}</span><span>Page ${n} of ${N}</span></div>`
+  const pgHdr = `<div class="pg-hdr"><div class="logo-sm">DealGap<span class="iq">IQ</span></div><div class="pg-hdr-title">${esc(d.property_address)}</div></div>`
+  const pgFt = (n: number) => `<div class="pg-foot"><span>DealGapIQ Property Report</span><span>${esc(dateStr)}</span><span>Page ${n} of ${N}</span></div>`
 
   const pages = `
 <!-- ===== PAGE 1: COVER + PROPERTY DETAILS ===== -->
@@ -226,12 +259,12 @@ function buildReport(d: Proforma, theme: string, photos: string[]): string {
   <div class="cover-top">
     <div class="logo-lg">DealGap<span class="iq">IQ</span></div>
     <div class="cover-type">Property Investment Report</div>
-    <div class="cover-date">${dateStr} &bull; ${d.strategy_type.toUpperCase()} Strategy</div>
+    <div class="cover-date">${esc(dateStr)} &bull; ${esc(d.strategy_type.toUpperCase())} Strategy</div>
   </div>
   ${photoHTML}
   <div class="cover-divider"></div>
-  <h1 class="cover-addr">${d.property_address}</h1>
-  <p class="cover-meta">${d.property.property_type} &bull; ${d.property.bedrooms} BD / ${d.property.bathrooms} BA &bull; ${fmt(d.property.square_feet)} sqft &bull; Built ${d.property.year_built}</p>
+  <h1 class="cover-addr">${esc(d.property_address)}</h1>
+  <p class="cover-meta">${esc(d.property.property_type)} &bull; ${d.property.bedrooms} BD / ${d.property.bathrooms} BA &bull; ${fmt(d.property.square_feet)} sqft &bull; Built ${d.property.year_built}</p>
   <div class="hero">
     <div class="hero-item"><div class="hero-val">${$(d.acquisition.purchase_price)}</div><div class="hero-lbl">Purchase Price</div></div>
     <div class="hero-item"><div class="hero-val">${$(d.income.monthly_rent)}</div><div class="hero-lbl">Monthly Rent</div></div>
@@ -243,8 +276,8 @@ function buildReport(d: Proforma, theme: string, photos: string[]): string {
   <p class="narrative">${narrativeCover(d)}</p>
   ${d.strategy_methodology ? `
   <div class="card mt-14" style="border-left:3px solid ${p.brand}">
-    <div class="card-hd">Strategy Methodology: ${d.strategy_type.toUpperCase()}</div>
-    <p class="narrative" style="margin:8px 0 0">${d.strategy_methodology.replace(/\*\*(.*?)\*\*/g, '<strong>$1</strong>').replace(/\n/g, ' ')}</p>
+    <div class="card-hd">Strategy Methodology: ${esc(d.strategy_type.toUpperCase())}</div>
+    <p class="narrative" style="margin:8px 0 0">${renderInlineMd(d.strategy_methodology)}</p>
   </div>` : ''}
   <div class="sec-divider"></div>
   <div class="sec-tag">01</div>
@@ -254,9 +287,9 @@ function buildReport(d: Proforma, theme: string, photos: string[]): string {
   <div class="grid3 mt-12">
     <div class="card">
       <div class="card-hd">Property Details</div>
-      ${kv('Address', d.property.address)}
-      ${kv('City / State', `${d.property.city}, ${d.property.state} ${d.property.zip}`)}
-      ${kv('Type', d.property.property_type)}
+      ${kv('Address', esc(d.property.address))}
+      ${kv('City / State', `${esc(d.property.city)}, ${esc(d.property.state)} ${esc(d.property.zip)}`)}
+      ${kv('Type', esc(d.property.property_type))}
       ${kv('Bedrooms', String(d.property.bedrooms))}
       ${kv('Bathrooms', String(d.property.bathrooms))}
       ${kv('Square Feet', fmt(d.property.square_feet))}
@@ -279,7 +312,7 @@ function buildReport(d: Proforma, theme: string, photos: string[]): string {
       ${kv('Down Payment', `${$(d.financing.down_payment)} (${pct(d.financing.down_payment_percent,0)})`)}
       ${kv('Loan Amount', $(d.financing.loan_amount))}
       ${kv('Interest Rate', pct(d.financing.interest_rate))}
-      ${kv('Loan Term', `${d.financing.loan_term_years} yrs (${d.financing.loan_type})`)}
+      ${kv('Loan Term', `${d.financing.loan_term_years} yrs (${esc(d.financing.loan_type)})`)}
       ${kv('Monthly P&I', $(d.financing.monthly_payment))}
       ${kv('Monthly w/ Escrow', $(d.financing.monthly_payment_with_escrow))}
       ${kv('Total Interest', $(d.financing.total_interest_over_life))}
@@ -293,7 +326,7 @@ function buildReport(d: Proforma, theme: string, photos: string[]): string {
   ${pgHdr}
   <div class="sec-tag">02</div>
   <h2 class="sec-title">Market Position &amp; Location Analysis</h2>
-  <p class="narrative">Located in ${d.property.city}, ${d.property.state}, this property benefits from the area's residential market dynamics. With an assumed annual appreciation of ${pct(d.projections.appreciation_rate,1)}, the investment leverages both rental income and long-term value growth. Strong fundamentals in the local housing market support the projected appreciation trajectory.</p>
+  <p class="narrative">Located in ${esc(d.property.city)}, ${esc(d.property.state)}, this property benefits from the area's residential market dynamics. With an assumed annual appreciation of ${pct(d.projections.appreciation_rate,1)}, the investment leverages both rental income and long-term value growth. Strong fundamentals in the local housing market support the projected appreciation trajectory.</p>
   <div class="grid4 mt-14">
     <div class="stat-card"><div class="stat-val">${pct(d.projections.appreciation_rate,1)}</div><div class="stat-lbl">Annual Appreciation</div></div>
     <div class="stat-card"><div class="stat-val">${pct(d.projections.rent_growth_rate,1)}</div><div class="stat-lbl">Rent Growth Rate</div></div>
@@ -394,7 +427,7 @@ function buildReport(d: Proforma, theme: string, photos: string[]): string {
   <div class="score-section">
     <div class="score-ring-wrap">${ring(d.deal_score.score, d.deal_score.grade, p, 150)}</div>
     <div class="score-text">
-      <h3 class="verdict-hd" style="color:${gc(d.deal_score.grade,p)}">${d.deal_score.verdict || `Grade ${d.deal_score.grade}`}</h3>
+      <h3 class="verdict-hd" style="color:${gc(d.deal_score.grade,p)}">${esc(d.deal_score.verdict || `Grade ${d.deal_score.grade}`)}</h3>
       <p class="narrative">${narrativeDealScore(d)}</p>
     </div>
   </div>
@@ -419,7 +452,7 @@ function buildReport(d: Proforma, theme: string, photos: string[]): string {
   </div>
   ${d.strategy_breakdown && !d.strategy_breakdown.error ? `
   <div class="card mt-14">
-    <div class="card-hd">${d.strategy_type.toUpperCase()} Strategy Breakdown</div>
+    <div class="card-hd">${esc(d.strategy_type.toUpperCase())} Strategy Breakdown</div>
     <div class="grid2">
       ${(() => {
         const b = d.strategy_breakdown!
@@ -500,7 +533,7 @@ function buildReport(d: Proforma, theme: string, photos: string[]): string {
   </div>` : ''}
   <div class="disclaimer">
     <h4>Data Sources</h4>
-    <p>RentCast Estimate: ${d.sources.rent_estimate_source} &bull; Property Value: ${d.sources.property_value_source} &bull; Tax Data: ${d.sources.tax_data_source} &bull; Market Data: ${d.sources.market_data_source} &bull; Data Freshness: ${d.sources.data_freshness}</p>
+    <p>RentCast Estimate: ${esc(d.sources.rent_estimate_source)} &bull; Property Value: ${esc(d.sources.property_value_source)} &bull; Tax Data: ${esc(d.sources.tax_data_source)} &bull; Market Data: ${esc(d.sources.market_data_source)} &bull; Data Freshness: ${esc(d.sources.data_freshness)}</p>
     <h4 class="mt-6">Disclaimer</h4>
     <p>This report is for informational purposes only and does not constitute investment advice. All projections are based on assumptions that may not materialize. Past performance is not indicative of future results. Market conditions, interest rates, rental demand, and property values can change significantly. Always conduct independent due diligence, consult qualified professionals, and verify all data before making investment decisions.</p>
     <p class="mt-4">&copy; ${now.getFullYear()} DealGapIQ. All rights reserved.</p>
@@ -558,7 +591,7 @@ function buildReport(d: Proforma, theme: string, photos: string[]): string {
   ${pgFt(6)}
 </div>`
 
-  return `<!DOCTYPE html><html lang="en"><head><meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1.0"><title>DealGapIQ Property Report — ${d.property_address}</title><link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin><link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet"><style>${css(p,dk)}</style><script>document.fonts.ready.then(function(){setTimeout(function(){window.print()},500)});</script></head><body>${pages}</body></html>`
+  return `<!DOCTYPE html><html lang="en"><head><meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1.0"><title>DealGapIQ Property Report — ${esc(d.property_address)}</title><link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin><link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet"><style>${css(p,dk)}</style><script>document.fonts.ready.then(function(){setTimeout(function(){window.print()},500)});</script></head><body>${pages}</body></html>`
 }
 
 // ---------------------------------------------------------------------------
@@ -718,8 +751,21 @@ export async function GET(request: NextRequest) {
     ])
 
     if (!proformaRes.ok) {
-      const err = await proformaRes.text()
-      return new NextResponse(`<html><body style="font-family:sans-serif;padding:40px;text-align:center"><h2>Report generation failed</h2><p>Status: ${proformaRes.status}</p><p>${err}</p></body></html>`, { status: 502, headers: { 'Content-Type': 'text/html' } })
+      // Log the upstream body server-side for debugging, but never echo it
+      // back to the user — backend stack traces / SQL / internal messages
+      // would otherwise be reflected into the report HTML.
+      const upstream = await proformaRes.text().catch(() => '')
+      console.error(`[api/report] proforma backend error ${proformaRes.status}:`, upstream.slice(0, 500))
+      const status = proformaRes.status
+      const userMessage = status === 401 || status === 403
+        ? 'You need a Pro subscription to generate this report.'
+        : status === 404
+          ? 'We could not find data for this property.'
+          : 'We could not generate this report right now. Please try again in a moment.'
+      return new NextResponse(
+        `<!DOCTYPE html><html lang="en"><head><meta charset="UTF-8"><title>Report unavailable</title></head><body style="font-family:system-ui,-apple-system,sans-serif;padding:40px;text-align:center;color:#0F172A"><h2 style="margin:0 0 8px">Report unavailable</h2><p style="color:#475569">${esc(userMessage)}</p></body></html>`,
+        { status: 502, headers: { 'Content-Type': 'text/html; charset=utf-8' } },
+      )
     }
 
     const proforma: Proforma = await proformaRes.json()
@@ -728,6 +774,11 @@ export async function GET(request: NextRequest) {
 
     return new NextResponse(buildReport(proforma, theme === 'dark' ? 'dark' : 'light', photos), { status: 200, headers: { 'Content-Type': 'text/html; charset=utf-8', 'Cache-Control': 'no-store' } })
   } catch (err) {
-    return new NextResponse(`<html><body style="font-family:sans-serif;padding:40px;text-align:center"><h2>Error</h2><p>${err instanceof Error ? err.message : String(err)}</p></body></html>`, { status: 500, headers: { 'Content-Type': 'text/html' } })
+    // Same policy as above: log internally, return a generic message.
+    console.error('[api/report] unhandled error:', err)
+    return new NextResponse(
+      `<!DOCTYPE html><html lang="en"><head><meta charset="UTF-8"><title>Report unavailable</title></head><body style="font-family:system-ui,-apple-system,sans-serif;padding:40px;text-align:center;color:#0F172A"><h2 style="margin:0 0 8px">Something went wrong</h2><p style="color:#475569">We could not generate this report right now. Please try again in a moment.</p></body></html>`,
+      { status: 500, headers: { 'Content-Type': 'text/html; charset=utf-8' } },
+    )
   }
 }

--- a/frontend/src/app/billing/loading.tsx
+++ b/frontend/src/app/billing/loading.tsx
@@ -48,12 +48,13 @@ export default function BillingLoading() {
               <div className="h-9 w-24 rounded bg-[var(--surface-elevated)] animate-pulse mb-1" />
               <div className="h-3 w-52 rounded bg-[var(--surface-elevated)] animate-pulse mb-7" />
               <div className="space-y-3 mb-8">
-                {Array.from({ length: 9 }).map((_, j) => (
+                {/* Deterministic widths so SSR + CSR match (no hydration mismatch). */}
+                {[78, 64, 84, 70, 88, 62, 80, 74, 86].map((w, j) => (
                   <div key={j} className="flex items-center gap-2.5">
                     <div className="w-[18px] h-[18px] rounded bg-[var(--surface-elevated)] animate-pulse flex-shrink-0" />
                     <div
                       className="h-4 rounded bg-[var(--surface-elevated)] animate-pulse"
-                      style={{ width: `${60 + Math.random() * 30}%` }}
+                      style={{ width: `${w}%` }}
                     />
                   </div>
                 ))}

--- a/frontend/src/app/checkout/success/page.tsx
+++ b/frontend/src/app/checkout/success/page.tsx
@@ -6,7 +6,7 @@
  * Address-dependent paths (verdict, property, strategy) redirect to /billing to avoid "No address provided".
  */
 
-import { useEffect, useMemo, useState } from 'react'
+import { Suspense, useEffect, useMemo, useState } from 'react'
 import { useRouter, useSearchParams } from 'next/navigation'
 import { CheckCircle, Loader2 } from 'lucide-react'
 import { api } from '@/lib/api-client'
@@ -20,7 +20,29 @@ function isAddressDependentPath(path: string): boolean {
   return p === '/discovery' || p === '/property' || p === '/strategy' || p.startsWith('/property/')
 }
 
+function CheckoutSuccessFallback() {
+  return (
+    <div
+      className="min-h-screen flex flex-col items-center justify-center px-4"
+      style={{ background: '#0B1120', color: '#E2E8F0' }}
+    >
+      <Loader2 className="w-14 h-14 mx-auto mb-6 text-sky-500 animate-spin" />
+      <p className="text-sm text-slate-400">Loading…</p>
+    </div>
+  )
+}
+
 export default function CheckoutSuccessPage() {
+  // useSearchParams requires a Suspense boundary in Next 16+; the actual
+  // polling + redirect logic lives in CheckoutSuccessContent.
+  return (
+    <Suspense fallback={<CheckoutSuccessFallback />}>
+      <CheckoutSuccessContent />
+    </Suspense>
+  )
+}
+
+function CheckoutSuccessContent() {
   const router = useRouter()
   const searchParams = useSearchParams()
   const sessionId = searchParams.get('session_id')

--- a/frontend/src/app/deal-maker/page.tsx
+++ b/frontend/src/app/deal-maker/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useCallback, useEffect, useState } from 'react'
+import { Suspense, useCallback, useEffect, useState } from 'react'
 import { useSearchParams, useRouter } from 'next/navigation'
 import { WEB_BASE_URL, IS_CAPACITOR } from '@/lib/env'
 import dynamic from 'next/dynamic'
@@ -25,6 +25,17 @@ const DealMakerScreen = dynamic(
 type ValidationStatus = 'idle' | 'validating' | 'valid' | 'issues' | 'error' | 'unavailable'
 
 export default function DealMakerIndexPage() {
+  // useSearchParams must be inside a Suspense boundary in Next 16+ to avoid
+  // CSR-bailout / static-render breakage. The actual page body lives in
+  // `DealMakerIndexContent` below.
+  return (
+    <Suspense fallback={<IQLoadingLogo />}>
+      <DealMakerIndexContent />
+    </Suspense>
+  )
+}
+
+function DealMakerIndexContent() {
   const searchParams = useSearchParams()
   const router = useRouter()
   const { fetchProperty } = usePropertyData()

--- a/frontend/src/app/map-search/page.tsx
+++ b/frontend/src/app/map-search/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useLayoutEffect, useRef, useState } from 'react'
+import { Suspense, useEffect, useLayoutEffect, useRef, useState } from 'react'
 import { MapSearchView } from '@/components/map-search/MapSearchView'
 
 // SSR-safe layout effect — falls back to useEffect on the server.
@@ -53,7 +53,25 @@ export default function MapSearchPage() {
       className="w-full overflow-hidden"
       style={{ height, backgroundColor: 'var(--surface-base)' }}
     >
-      <MapSearchView />
+      {/*
+        MapSearchView calls useSearchParams() — wrap in Suspense per Next 16+
+        requirements so static rendering / partial prerendering doesn't bail.
+      */}
+      <Suspense
+        fallback={
+          <div
+            className="w-full h-full flex items-center justify-center"
+            style={{ backgroundColor: 'var(--surface-base)' }}
+          >
+            <div
+              className="w-8 h-8 rounded-full border-2 border-t-transparent animate-spin"
+              style={{ borderColor: 'var(--accent-sky)' }}
+            />
+          </div>
+        }
+      >
+        <MapSearchView />
+      </Suspense>
     </div>
   )
 }

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -28,14 +28,26 @@ import { AddressAutocomplete } from '@/components/AddressAutocomplete';
 import { canonicalizeAddressForIdentity, isLikelyFullAddress } from '@/utils/addressIdentity';
 import type { GeocodedProperty } from '@/lib/reverseGeocode';
 
+type HomepageVariant = '2' | '3' | '4';
+
 export default function HomePage() {
   const [mode, setMode] = useState<'landing' | 'camera'>('landing');
+  // Variant defaults to V4 on the server and on the first client paint so SSR
+  // and hydration agree. The `?v=2|3` query flag is an internal rollback
+  // escape hatch; we apply it after hydration to avoid React's hydration-
+  // mismatch warning and the flash of replaced subtree.
+  const [variant, setVariant] = useState<HomepageVariant>('4');
 
   useEffect(() => {
     const params = new URLSearchParams(window.location.search);
     if (params.get('scan') === 'true') {
       setMode('camera');
       window.history.replaceState({}, '', '/');
+      return;
+    }
+    const v = params.get('v');
+    if (v === '2' || v === '3') {
+      setVariant(v);
     }
   }, []);
 
@@ -44,15 +56,12 @@ export default function HomePage() {
     return <MobileScannerView onSwitchMode={() => setMode('landing')} />;
   }
 
-  // V4 = marketing-tuned homepage. V3 and V2 remain available via query flags for rollback.
-  if (typeof window !== 'undefined') {
-    const version = new URLSearchParams(window.location.search).get('v');
-    if (version === '2') {
-      return <DealGapIQHomepageV2 onPointAndScan={() => setMode('camera')} />;
-    }
-    if (version === '3') {
-      return <DealGapIQHomepageV3 onPointAndScan={() => setMode('camera')} />;
-    }
+  // V4 = marketing-tuned homepage. V3 and V2 remain available via ?v= for rollback.
+  if (variant === '2') {
+    return <DealGapIQHomepageV2 onPointAndScan={() => setMode('camera')} />;
+  }
+  if (variant === '3') {
+    return <DealGapIQHomepageV3 onPointAndScan={() => setMode('camera')} />;
   }
   return <DealGapIQHomepageV4 onPointAndScan={() => setMode('camera')} />;
 }
@@ -409,7 +418,7 @@ function MobileScannerView({ onSwitchMode }: { onSwitchMode: () => void }) {
             {isAuthenticated && user ? (
               <>
                 <button
-                  onClick={() => router.push('/search')}
+                  onClick={() => router.push('/dashboard')}
                   className="flex items-center gap-1 bg-brand-500/80 backdrop-blur-sm px-3 py-1.5 rounded-full"
                 >
                   <LayoutGrid className="w-3 h-3 text-white" />

--- a/frontend/src/components/LayoutWrapper.tsx
+++ b/frontend/src/components/LayoutWrapper.tsx
@@ -19,6 +19,7 @@ import React, { Suspense } from 'react'
 import { AppHeader } from './AppHeader'
 import { UsageBar } from './UsageBar'
 import { DashboardLandingGate } from './DashboardLandingGate'
+import { OfflineBanner } from './OfflineBanner'
 
 interface LayoutWrapperProps {
   children: React.ReactNode
@@ -34,6 +35,12 @@ export function LayoutWrapper({ children }: LayoutWrapperProps) {
       >
         Skip to main content
       </a>
+
+      {/*
+        Network status banner — fixed position, sits above all chrome.
+        Self-hides when online; shows a brief "Back Online" confirmation on reconnect.
+      */}
+      <OfflineBanner />
 
       {/* 
         Universal AppHeader - wrapped in Suspense for useSearchParams compatibility.

--- a/frontend/src/components/MobileLandingPage.tsx
+++ b/frontend/src/components/MobileLandingPage.tsx
@@ -92,7 +92,7 @@ export function MobileLandingPage({ onPointAndScan }: LandingPageProps) {
           {isAuthenticated && user ? (
             <>
               <button
-                onClick={() => router.push('/search')}
+                onClick={() => router.push('/dashboard')}
                 className={`text-sm font-medium transition-colors ${
                   isDark 
                     ? 'text-white/70 hover:text-white' 

--- a/frontend/src/components/auth/AuthModal.tsx
+++ b/frontend/src/components/auth/AuthModal.tsx
@@ -96,18 +96,18 @@ export default function AuthModal() {
       aria-modal="true"
       aria-label={view === 'login' ? 'Sign in' : view === 'register' ? 'Create account' : 'Reset password'}
     >
-      <div className="w-full max-w-md rounded-2xl shadow-xl overflow-hidden" style={{ backgroundColor: 'var(--surface-card)', border: '1px solid rgba(255,255,255,0.1)' }}>
+      <div className="w-full max-w-md rounded-2xl shadow-xl overflow-hidden" style={{ backgroundColor: 'var(--surface-card)', border: '1px solid var(--border-default)' }}>
         {/* Header */}
         <div className="flex items-center justify-between px-6 pt-6 pb-2">
-          <h2 className="text-xl font-bold" style={{ color: '#FFFFFF' }}>
+          <h2 className="text-xl font-bold" style={{ color: 'var(--text-heading)' }}>
             {view === 'login' && 'Sign In'}
             {view === 'register' && 'Create Account'}
             {view === 'forgot-password' && 'Reset Password'}
           </h2>
           <button
             onClick={close}
-            className="p-1 rounded-full hover:bg-white/10 transition-colors"
-            style={{ color: '#94A3B8' }}
+            className="p-1 rounded-full hover:bg-[var(--surface-card-hover)] transition-colors"
+            style={{ color: 'var(--text-muted)' }}
             aria-label="Close"
           >
             <X className="w-5 h-5" />

--- a/frontend/src/hooks/useDealScore.ts
+++ b/frontend/src/hooks/useDealScore.ts
@@ -122,6 +122,9 @@ export function useDealScore(
   
   const timeoutRef = useRef<NodeJS.Timeout | null>(null)
   const abortControllerRef = useRef<AbortController | null>(null)
+  // Tracks the very first effect run so `fetchOnMount: false` can suppress it
+  // without affecting subsequent input-change refetches.
+  const isFirstRunRef = useRef(true)
   
   const fetchDealScore = useCallback(async () => {
     // Cancel any pending request
@@ -221,8 +224,15 @@ export function useDealScore(
     input.daysOnMarket,
   ])
   
-  // Debounced fetch when inputs change
+  // Debounced fetch when inputs change.
+  // Skips the very first run when `fetchOnMount === false` so callers that
+  // want to defer the initial calculation (e.g. wait for user input) can.
   useEffect(() => {
+    if (isFirstRunRef.current) {
+      isFirstRunRef.current = false
+      if (!fetchOnMount) return
+    }
+
     if (timeoutRef.current) {
       clearTimeout(timeoutRef.current)
     }
@@ -236,7 +246,7 @@ export function useDealScore(
         clearTimeout(timeoutRef.current)
       }
     }
-  }, [fetchDealScore, debounceMs])
+  }, [fetchDealScore, debounceMs, fetchOnMount])
   
   // Cleanup on unmount
   useEffect(() => {

--- a/frontend/src/hooks/useDefaults.ts
+++ b/frontend/src/hooks/useDefaults.ts
@@ -21,7 +21,7 @@
  * ```
  */
 
-import { useState, useEffect, useCallback, useRef } from 'react'
+import { useState, useEffect, useCallback } from 'react'
 import { defaultsService, ResolvedDefaultsResponse } from '@/services/defaults'
 import type { AllAssumptions } from '@/stores/index'
 
@@ -55,10 +55,7 @@ export function useDefaults(zipCode?: string): UseDefaultsResult {
   const [fullResponse, setFullResponse] = useState<ResolvedDefaultsResponse | null>(null)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<Error | null>(null)
-  
-  // Track the ZIP code to detect changes
-  const prevZipCodeRef = useRef<string | undefined>(zipCode)
-  
+
   const fetchDefaults = useCallback(async () => {
     setLoading(true)
     setError(null)
@@ -82,19 +79,13 @@ export function useDefaults(zipCode?: string): UseDefaultsResult {
       setLoading(false)
     }
   }, [zipCode])
-  
-  // Fetch on mount and when ZIP code changes
+
+  // Single fetch effect keyed on `fetchDefaults`. Because `fetchDefaults`
+  // is itself memoized on `zipCode`, this fires exactly once per mount and
+  // exactly once per ZIP change — no double-fetch races.
   useEffect(() => {
     fetchDefaults()
   }, [fetchDefaults])
-  
-  // Refetch when ZIP code changes
-  useEffect(() => {
-    if (prevZipCodeRef.current !== zipCode) {
-      prevZipCodeRef.current = zipCode
-      fetchDefaults()
-    }
-  }, [zipCode, fetchDefaults])
   
   // Check if a specific field is from user override
   const isUserOverride = useCallback(

--- a/frontend/src/hooks/useMapSearch.ts
+++ b/frontend/src/hooks/useMapSearch.ts
@@ -160,6 +160,18 @@ export function useMapSearch() {
     }
   }, [fetchListings])
 
+  // Cancel any pending bounds-debounce on unmount so we never
+  // fire fetchListings (or its setState calls) after the consumer
+  // has navigated away from the map.
+  useEffect(() => {
+    return () => {
+      if (debounceRef.current) {
+        clearTimeout(debounceRef.current)
+        debounceRef.current = null
+      }
+    }
+  }, [])
+
   const updateFilters = useCallback(
     (next: Partial<MapSearchFilters>) => {
       const needsRefetch = (

--- a/frontend/src/hooks/useSession.ts
+++ b/frontend/src/hooks/useSession.ts
@@ -27,6 +27,12 @@ import {
   type LoginResponse,
   type MFAChallengeResponse,
 } from '@/lib/api-client'
+import { SAVED_PROPERTIES_KEYS } from '@/hooks/useSavedProperties'
+import { SEARCH_HISTORY_KEYS } from '@/hooks/useSearchHistory'
+import { TIMELINE_KEYS } from '@/hooks/useTimeline'
+import { TASKS_KEYS } from '@/hooks/useTasks'
+import { CONTACTS_KEYS } from '@/hooks/useContacts'
+import { DOCUMENTS_KEYS } from '@/hooks/useDocuments'
 
 // ------------------------------------------------------------------
 // Query key
@@ -43,15 +49,21 @@ export const SESSION_QUERY_KEY = ['session', 'me'] as const
 const SESSION_STORAGE_KEY = 'dgiq_session'
 const SESSION_MAX_AGE_MS = 8 * 60 * 60 * 1000 // 8 hours — well within session TTL
 
+/**
+ * Persisted session snapshot.
+ *
+ * Intentionally OMITS `roles`, `permissions`, and `is_superuser` — those
+ * authority fields must never be sourced from localStorage because a local
+ * user can trivially edit them and trick the UI into showing admin chrome
+ * (or other gated UX) until /me resolves. They are populated only after
+ * the authoritative /me round-trip succeeds.
+ */
 interface PersistedSession {
   id: string
   email: string
   full_name: string | null
   subscription_tier: 'free' | 'pro'
   subscription_status: string
-  roles: string[]
-  permissions: string[]
-  is_superuser: boolean
   onboarding_completed: boolean
   /** Map-search default location — needed on first paint so the map can
       open at the saved ZIP without waiting for /me to resolve. */
@@ -67,9 +79,6 @@ function persistSession(user: UserResponse): void {
       full_name: user.full_name,
       subscription_tier: user.subscription_tier,
       subscription_status: user.subscription_status,
-      roles: user.roles ?? [],
-      permissions: user.permissions ?? [],
-      is_superuser: user.is_superuser,
       onboarding_completed: user.onboarding_completed,
       business_address_zip: user.business_address_zip ?? null,
       ts: Date.now(),
@@ -89,6 +98,10 @@ function readPersistedSession(): UserResponse | null {
       localStorage.removeItem(SESSION_STORAGE_KEY)
       return null
     }
+    // Authority fields default to "no privileges" — they will be replaced
+    // by the real values from /me as soon as it resolves. This guarantees
+    // the persisted snapshot can never grant a user privileges they don't
+    // actually have on the server.
     return {
       id: data.id,
       email: data.email,
@@ -96,14 +109,14 @@ function readPersistedSession(): UserResponse | null {
       avatar_url: null,
       is_active: true,
       is_verified: true,
-      is_superuser: data.is_superuser,
+      is_superuser: false,
       mfa_enabled: false,
       created_at: '',
       last_login: null,
       has_profile: true,
       onboarding_completed: data.onboarding_completed,
-      roles: data.roles,
-      permissions: data.permissions,
+      roles: [],
+      permissions: [],
       subscription_tier: data.subscription_tier,
       subscription_status: data.subscription_status,
       business_address_zip: data.business_address_zip ?? null,
@@ -319,8 +332,22 @@ export function useLogout() {
       _lastKnownUser = null
       clearPersistedSession()
       _lastTokenRefreshAt = 0
+
+      // Targeted invalidation: drop everything tied to the user's identity
+      // (saved properties, search history, timeline, tasks, contacts, documents,
+      // billing/subscription) but keep anonymous lookups (e.g. property-search
+      // by address) so the next visitor on this device doesn't pay a cold cache.
       queryClient.setQueryData(SESSION_QUERY_KEY, null)
-      queryClient.clear()
+      queryClient.removeQueries({ queryKey: SAVED_PROPERTIES_KEYS.all })
+      queryClient.removeQueries({ queryKey: SEARCH_HISTORY_KEYS.all })
+      queryClient.removeQueries({ queryKey: TIMELINE_KEYS.all })
+      queryClient.removeQueries({ queryKey: TASKS_KEYS.all })
+      queryClient.removeQueries({ queryKey: CONTACTS_KEYS.all })
+      queryClient.removeQueries({ queryKey: DOCUMENTS_KEYS.all })
+      queryClient.removeQueries({ queryKey: ['billing'] })
+      queryClient.removeQueries({ queryKey: ['subscription'] })
+      queryClient.removeQueries({ queryKey: ['rehab-budget'] })
+
       router.push('/')
     },
   })

--- a/frontend/src/hooks/useWorksheetProperty.ts
+++ b/frontend/src/hooks/useWorksheetProperty.ts
@@ -35,127 +35,119 @@ export function useWorksheetProperty(propertyId: string, options: UseWorksheetPr
   const [property, setProperty] = useState<SavedProperty | null>(null)
   const [isLoading, setIsLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
-  
-  // Use ref to avoid re-fetching when onLoaded changes (prevents infinite loop)
+
+  // Avoid retriggering the fetch effect when callers pass a fresh
+  // `onLoaded` reference each render.
   const onLoadedRef = useRef(onLoaded)
   onLoadedRef.current = onLoaded
-  
-  // Track if we've already fetched to prevent duplicate fetches
-  const hasFetchedRef = useRef(false)
+
+  // Snapshot worksheet store fields read inside the effect into refs so
+  // they can be consulted without becoming dependencies (which would
+  // otherwise refetch every store mutation).
+  const worksheetSnapshotRef = useRef(worksheetStore)
+  worksheetSnapshotRef.current = worksheetStore
 
   useEffect(() => {
-    // Don't do anything while auth is still loading
-    if (authLoading) {
-      console.log('[useWorksheetProperty] Auth still loading, waiting...')
-      return
-    }
-    
-    // Only redirect if auth is done loading AND user is not authenticated
+    // Don't do anything while auth is still loading.
+    if (authLoading) return
+
+    // Only redirect if auth is done loading AND user is not authenticated.
     if (!isAuthenticated) {
-      console.log('[useWorksheetProperty] Not authenticated, redirecting to home')
       router.push('/')
       return
     }
-    
-    // Handle temporary (unsaved) properties - use worksheetStore data instead of API
-    const isTemp = isTempPropertyId(propertyId)
-    if (isTemp) {
-      
-      if (worksheetStore.propertyId === propertyId && worksheetStore.propertyData) {
-        // WorksheetStore already has this property's data
-        const syntheticProperty = worksheetStore.propertyData as SavedProperty
-        setProperty(syntheticProperty)
-        setIsLoading(false)
-        setError(null)
-        onLoadedRef.current?.(syntheticProperty)
-        return
-      } else {
-        // worksheetStore doesn't have this property data - should have been initialized by Deal Maker
-        // Check if we at least have assumptions we can use
-        if (worksheetStore.assumptions?.purchasePrice > 0) {
-          // Build a minimal synthetic property from worksheetStore
-          const syntheticProperty = {
-            id: propertyId,
-            user_id: '',
-            address_street: extractAddressFromTempId(propertyId),
-            address_city: '',
-            address_state: '',
-            address_zip: '',
-            property_data_snapshot: {
-              listPrice: worksheetStore.assumptions.purchasePrice,
-              monthlyRent: worksheetStore.assumptions.monthlyRent,
-              propertyTaxes: worksheetStore.assumptions.propertyTaxes,
-              insurance: worksheetStore.assumptions.insurance,
-            },
-            worksheet_assumptions: worksheetStore.assumptions,
-            created_at: new Date().toISOString(),
-            updated_at: new Date().toISOString(),
-          } as unknown as SavedProperty
+
+    if (!propertyId) return
+
+    let cancelled = false
+
+    // Fully reset state at the top of every (propertyId, auth) change so
+    // navigating between properties never leaves stale data on screen.
+    setProperty(null)
+    setError(null)
+    setIsLoading(true)
+
+    // Temporary (unsaved) properties: hydrate from the worksheet store
+    // rather than calling the API.
+    if (isTempPropertyId(propertyId)) {
+      const ws = worksheetSnapshotRef.current
+
+      if (ws.propertyId === propertyId && ws.propertyData) {
+        const syntheticProperty = ws.propertyData as SavedProperty
+        if (!cancelled) {
           setProperty(syntheticProperty)
           setIsLoading(false)
-          setError(null)
           onLoadedRef.current?.(syntheticProperty)
-          return
         }
-        // No data available, show error
+        return () => {
+          cancelled = true
+        }
+      }
+
+      if (ws.assumptions?.purchasePrice > 0) {
+        const syntheticProperty = {
+          id: propertyId,
+          user_id: '',
+          address_street: extractAddressFromTempId(propertyId),
+          address_city: '',
+          address_state: '',
+          address_zip: '',
+          property_data_snapshot: {
+            listPrice: ws.assumptions.purchasePrice,
+            monthlyRent: ws.assumptions.monthlyRent,
+            propertyTaxes: ws.assumptions.propertyTaxes,
+            insurance: ws.assumptions.insurance,
+          },
+          worksheet_assumptions: ws.assumptions,
+          created_at: new Date().toISOString(),
+          updated_at: new Date().toISOString(),
+        } as unknown as SavedProperty
+        if (!cancelled) {
+          setProperty(syntheticProperty)
+          setIsLoading(false)
+          onLoadedRef.current?.(syntheticProperty)
+        }
+        return () => {
+          cancelled = true
+        }
+      }
+
+      if (!cancelled) {
         setError('Property data not found. Please go back to Deal Maker.')
         setIsLoading(false)
-        return
+      }
+      return () => {
+        cancelled = true
       }
     }
 
-    const fetchProperty = async () => {
-      if (!propertyId || hasFetchedRef.current) {
-        console.log('[useWorksheetProperty] Skipping fetch:', { propertyId, hasFetched: hasFetchedRef.current })
-        return
-      }
-      
-      hasFetchedRef.current = true
-      setIsLoading(true)
-      setError(null)
-      
-      console.log('[useWorksheetProperty] Fetching property:', propertyId)
-      
-      try {
-        const data = await apiRequest<SavedProperty>(
-          `/api/v1/properties/saved/${propertyId}`
-        )
-        console.log('[useWorksheetProperty] Property loaded:', data.id, data.address_street)
-        
+    // Saved property: fetch from API.
+    apiRequest<SavedProperty>(`/api/v1/properties/saved/${propertyId}`)
+      .then((data) => {
+        if (cancelled) return
         setProperty(data)
         onLoadedRef.current?.(data)
-      } catch (err) {
-        console.error('[useWorksheetProperty] Error fetching property:', err)
-        
-        // apiRequest handles 401 → refresh automatically.
-        // If we still get an error, it's a real failure.
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return
         const message = err instanceof Error ? err.message : 'Failed to load property'
-        
+
         if (message.includes('401') || message.includes('Unauthorized')) {
           setError('Session expired. Please log in again.')
           router.push('/')
           return
         }
-        
-        setError(message || 'Failed to load property. Please try again.')
-      } finally {
-        setIsLoading(false)
-      }
-    }
 
-    fetchProperty()
-    // Note: worksheetStore values intentionally excluded from deps to prevent infinite loops
-    // The effect runs once per propertyId change, and worksheetStore data is read at that moment
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+        setError(message || 'Failed to load property. Please try again.')
+      })
+      .finally(() => {
+        if (!cancelled) setIsLoading(false)
+      })
+
+    return () => {
+      cancelled = true
+    }
   }, [propertyId, isAuthenticated, authLoading, router])
-  
-  // Reset fetch flag when propertyId changes
-  useEffect(() => {
-    hasFetchedRef.current = false
-    setProperty(null)
-    setError(null)
-    setIsLoading(true)
-  }, [propertyId])
 
   return {
     property,

--- a/frontend/src/lib/api/axesso-client.ts
+++ b/frontend/src/lib/api/axesso-client.ts
@@ -25,9 +25,15 @@ export interface AxessoResponse<T> {
   durationMs: number
 }
 
+// SECURITY: apiKey is intentionally always empty in the browser bundle.
+// Comps go through our backend (/api/v1/similar-*), which authenticates
+// to Axesso server-side using a secret env var. Reading
+// NEXT_PUBLIC_AXESSO_API_KEY here would expose the third-party subscription
+// key to anyone who downloads the JS bundle — see CI guard in
+// .github/workflows/ci.yml that fails if NEXT_PUBLIC_AXESSO* is reintroduced.
 const DEFAULT_CONFIG: AxessoClientConfig = {
   baseUrl: API_BASE_URL,
-  apiKey: typeof process !== 'undefined' ? (process.env.NEXT_PUBLIC_AXESSO_API_KEY ?? '') : '',
+  apiKey: '',
   defaultTimeout: 15_000,
   maxRetries: 3,
   retryableStatuses: [502, 503, 504],

--- a/frontend/src/lib/api/axesso-client.ts
+++ b/frontend/src/lib/api/axesso-client.ts
@@ -26,11 +26,11 @@ export interface AxessoResponse<T> {
 }
 
 // SECURITY: apiKey is intentionally always empty in the browser bundle.
-// Comps go through our backend (/api/v1/similar-*), which authenticates
-// to Axesso server-side using a secret env var. Reading
-// NEXT_PUBLIC_AXESSO_API_KEY here would expose the third-party subscription
-// key to anyone who downloads the JS bundle — see CI guard in
-// .github/workflows/ci.yml that fails if NEXT_PUBLIC_AXESSO* is reintroduced.
+// Comps go through our backend (/api/v1/similar-*), which authenticates to
+// the third-party comps provider server-side using a secret env var. Pulling
+// any provider key off `process.env` here would inline it into the JS bundle
+// (account / quota theft). The CI workflow has a grep guard that fails the
+// build if a forbidden public-prefix env name is reintroduced in src/.
 const DEFAULT_CONFIG: AxessoClientConfig = {
   baseUrl: API_BASE_URL,
   apiKey: '',

--- a/frontend/vercel.json
+++ b/frontend/vercel.json
@@ -22,7 +22,7 @@
         },
         {
           "key": "Content-Security-Policy",
-          "value": "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://*.sentry.io https://*.sentry-cdn.com https://*.vercel-scripts.com https://*.vercel-insights.com https://vercel.live https://maps.googleapis.com https://*.google.com https://*.gstatic.com https://js.stripe.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; connect-src 'self' https: wss: http://localhost:* ws://localhost:* https://*.sentry.io https://*.vercel-insights.com https://maps.googleapis.com https://*.google.com https://api.stripe.com; img-src * data: blob:; font-src 'self' data: https://fonts.gstatic.com; frame-src 'self' https://js.stripe.com https://hooks.stripe.com; frame-ancestors 'none'; worker-src 'self' blob:; base-uri 'self'; form-action 'self'"
+          "value": "default-src 'self'; script-src 'self' 'unsafe-inline' https://*.sentry.io https://*.sentry-cdn.com https://*.vercel-scripts.com https://*.vercel-insights.com https://vercel.live https://maps.googleapis.com https://*.google.com https://*.gstatic.com https://js.stripe.com; style-src 'self' 'unsafe-inline'; connect-src 'self' https: wss: https://*.sentry.io https://*.vercel-insights.com https://maps.googleapis.com https://*.google.com https://api.stripe.com; img-src * data: blob:; font-src 'self' data:; frame-src 'self' https://js.stripe.com https://hooks.stripe.com; frame-ancestors 'none'; worker-src 'self' blob:; base-uri 'self'; form-action 'self'"
         }
       ]
     }


### PR DESCRIPTION
## Summary

Phase 1 of a phased frontend audit-remediation roadmap. Fixes **17 distinct issues** across critical bugs, security, and stability — the items that should block the next major release. Diff is `+371 / -171` across 18 files; no architecture-level changes (those land in Phase 2).

## What's in this PR

### Critical bug fixes

| ID | Fix | Files |
|---|---|---|
| **B1** | `AuthModal` heading was `#FFFFFF` on `var(--surface-card)` (also `#FFFFFF` in light mode) → invisible "Sign In"/"Create Account" titles. Now uses `var(--text-heading)`. | `src/components/auth/AuthModal.tsx` |
| **B2** | `/compare` was permanently redirected to `/price-intel?view=sale`, but `app/compare/page.tsx` is the saved-property comparison UI keyed on `?ids=` — Price Intel ignores `ids`. The redirect silently broke comparison. Removed. | `next.config.js` |
| **B3** | Homepage `?v=2|3` branched on `window` during render → React hydration mismatch. Variant detection deferred to `useEffect`; SSR + first paint always render V4. | `src/app/page.tsx` |
| **B4** | `useWorksheetProperty` had two effects whose ordering left `hasFetchedRef` stale on `propertyId` change → could show property A's data after navigating to B. Collapsed into one cancellable effect, also clears state at the top of every key change. | `src/hooks/useWorksheetProperty.ts` |
| **B5** | `useLogout` ran `queryClient.clear()`, wiping every cache (property-search, comps, defaults, etc.) — not just session. Now invalidates only personalized keys (`saved-properties`, `search-history`, `timeline`, `tasks`, `contacts`, `documents`, `billing`, `subscription`, `rehab-budget`). | `src/hooks/useSession.ts` |
| **B6** | `MobileLandingPage` button labeled "Dashboard" called `router.push('/search')`. Same mislabel in `app/page.tsx` mobile-scanner header. Both now route to `/dashboard`. | `src/components/MobileLandingPage.tsx`, `src/app/page.tsx` |
| **B7** | `useSearchParams` callers without ancestor `<Suspense>` — risks Next 16 static-render bailout. Wrapped: `deal-maker`, `checkout/success`, `map-search`. | `src/app/deal-maker/page.tsx`, `src/app/checkout/success/page.tsx`, `src/app/map-search/page.tsx` |
| **B8** | `OfflineBanner` was implemented (with `aria-live="assertive"`) but never mounted. Mounted in `LayoutWrapper` so users on flaky connections see "No Internet Connection" / "Back Online". | `src/components/LayoutWrapper.tsx` |
| **B9** | `useDealScore` declared an `fetchOnMount` option but ignored it — every caller paid the initial fetch. Now honored via a first-run ref so callers passing `false` actually defer. | `src/hooks/useDealScore.ts` |
| **B10** | `useMapSearch` debounce `setTimeout` had no unmount cleanup → setState-after-unmount races. Cleared on unmount. | `src/hooks/useMapSearch.ts` |
| **B11** | `useDefaults` had two effects that both called `fetchDefaults()` on ZIP change → duplicate network request per ZIP transition. Collapsed to one. | `src/hooks/useDefaults.ts` |
| **B12** | `billing/loading.tsx` skeleton bar widths used `Math.random()` → SSR/CSR mismatch. Replaced with deterministic widths. | `src/app/billing/loading.tsx` |
| **B15** | Persisted session snapshot (`dgiq_session` in localStorage) included `roles`, `permissions`, `is_superuser` — a local user can edit JSON to spoof admin chrome until `/me` resolves. Stripped those fields; persisted snapshot now defaults privileges to "none" and only the authoritative `/me` response can grant them. | `src/hooks/useSession.ts` |

### Security hardening

| ID | Fix | Files |
|---|---|---|
| **SEC1** | `vercel.json` CSP allowed `'unsafe-eval'` in production, overriding the safer `next.config.js` policy. Removed `'unsafe-eval'`, dropped `localhost`/`fonts.*` since fonts are now self-hosted via `next/font`. | `vercel.json` |
| **SEC2** | Added two CI guards in `.github/workflows/ci.yml`: a source-side grep that fails on `NEXT_PUBLIC_(AXESSO\|RENTCAST\|ZILLOW\|REDFIN\|REALTOR\|ADMIN\|.*_SECRET\|.*_PRIVATE_KEY\|STRIPE_SECRET)` references in `src/`, and a bundle-side grep that scans the produced `.next/static` JS for the same. Removed the lone existing reference (`NEXT_PUBLIC_AXESSO_API_KEY` in `axesso-client.ts`) — comps already proxy through the backend, so the field is now hardcoded empty. | `.github/workflows/ci.yml`, `src/lib/api/axesso-client.ts` |
| **SEC3** | `/api/report/route.ts` interpolated backend strings into HTML without escaping (`strategy_methodology`, `property_address`, photo URLs, etc.) and reflected raw upstream error bodies → XSS + info disclosure surface. Added `esc()` + `renderInlineMd()`, escaped every user-controlled interpolation, validated photo URLs are http(s), and replaced the error-reflection page with generic copy + server-side log. | `src/app/api/report/route.ts` |

## Verification

| Check | Result |
|---|---|
| `npm run lint` | ✅ 0 errors (631 pre-existing warnings, none introduced) |
| `npx tsc --noEmit` | ✅ 0 errors |
| `npm run test:run` | ✅ 136 / 136 passing |
| `npm run build` | ✅ All 60+ routes built |
| New CI source guard (local) | ✅ Pass |
| New CI bundle guard (local) | ✅ Pass |
| `npm run theme:check:strict` | ⚠️ 59 pre-existing violations in `DealGapIQHomepageV2.tsx` + `VideoModal.tsx` — Phase 2; **no regressions from this PR** |

## Behavior changes worth knowing

1. **`useLogout`** no longer calls `queryClient.clear()`. Anonymous queries (e.g. `['property-search', address]`) survive logout — fewer cold caches for the next visitor on the same device.
2. **Persisted session snapshot** loses `roles`, `permissions`, `is_superuser`. After a hard refresh, the user has no privileges until `/auth/me` resolves. Subscription tier/status are still snapshotted (needed for first-paint paywall decisions).
3. **Homepage `?v=2|3`** still works as a rollback flag, but variants now apply after hydration. First paint always renders V4 — brief swap to V2/V3 if `?v=` is set.
4. **`/compare` redirect removed** — saved-property comparison page serves its own UI again.
5. **`/api/report` error page** no longer reflects upstream backend bodies. Server-side logs (`[api/report] proforma backend error N: …`) carry the detail.

## Test plan

- [ ] Sign-in modal renders titles legibly in **light mode** (`/?auth=login`)
- [ ] Sign-in modal renders titles legibly in **dark mode**
- [ ] Hard-load `/?v=2` and `/?v=3` — V4 should paint, then swap; no React hydration warning in console
- [ ] `/compare?ids=<id1>,<id2>` renders the comparison UI (not Price Intel)
- [ ] `/deal-maker`, `/checkout/success?session_id=...`, `/map-search` all load without "useSearchParams() should be wrapped in a suspense boundary" warnings
- [ ] Toggle airplane mode → red "No Internet Connection" banner appears; back online → green "Back Online" then auto-dismiss
- [ ] On `MobileLandingPage` and the camera-scanner header, signed-in "Dashboard" CTA navigates to `/dashboard`
- [ ] Save property A → open worksheet → navigate to property B's worksheet without remount → property B data shown (not A)
- [ ] Logout → property-search cache for previously-viewed addresses still hits (no cold fetch)
- [ ] Edit `localStorage.dgiq_session` to set `is_superuser: true` and refresh → admin nav does **not** show until /me responds (and then only if backend authorizes)
- [ ] Production response headers do **not** include `'unsafe-eval'` in `Content-Security-Policy`
- [ ] CI runs both new guard steps green; reintroduce a `NEXT_PUBLIC_AXESSO_*` reference locally and confirm CI fails

## Out of scope (Phase 2+)

- Splitting `app/strategy/page.tsx` (2.2k LOC), `app/discovery/page.tsx` (2.1k LOC), `DealMakerPopup.tsx` (1.8k LOC)
- Consolidating V2/V3/V4 landing pages
- Building shared `Modal` / `Slider` / `Skeleton` primitives in `components/ui/`
- Migrating `useDefaults`, `useIQAnalysis`, `useDealMakerBackendCalc` to React Query
- Tightening `connect-src` / migrating to nonce-based CSP
- Removing `axios` and `recharts` (dead dependencies)
- Pre-existing strict theme-check failures in `DealGapIQHomepageV2.tsx` and `VideoModal.tsx`


Made with [Cursor](https://cursor.com)