### PR TITLE
chore(frontend): P2.2 — theme contract fixes (VideoModal + MobileLandingPage)

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -51,6 +51,9 @@
   --surface-elevated: #0c1220;
   --surface-input: #0c1220;
   --surface-overlay: rgba(0, 0, 0, 0.8);
+  /* Constant in both themes — used for video letterboxing and similar
+     cases where pure black is industry-standard regardless of UI theme. */
+  --surface-media-letterbox: #000000;
 
   --text-heading: #f1f5f9;
   --text-body: #cbd5e1;

--- a/frontend/src/components/MobileLandingPage.tsx
+++ b/frontend/src/components/MobileLandingPage.tsx
@@ -82,13 +82,7 @@ export function MobileLandingPage({ onPointAndScan }: LandingPageProps) {
   }
 
   return (
-    <div
-      className={`min-h-screen overflow-x-hidden transition-colors duration-300 ${
-        isDark
-          ? 'bg-[#07172e] text-[#e1e8ed]'
-          : 'bg-[var(--surface-base)] text-[var(--text-heading)]'
-      }`}
-    >
+    <div className="min-h-screen overflow-x-hidden transition-colors duration-300 bg-[var(--surface-base)] text-[var(--text-body)]">
       {/* Header — solid card surface in light so canvas tint starts below */}
       <header
         className={`relative z-10 w-full px-5 py-3 lg:px-12 lg:py-5 ${
@@ -387,10 +381,8 @@ export function MobileLandingPage({ onPointAndScan }: LandingPageProps) {
 
       {/* Bottom Nav (Mobile Style) */}
       <nav
-        className={`flex justify-around py-3 px-5 ${isDark ? 'bg-[#061324]' : 'bg-[var(--surface-card)]'}`}
-        style={{
-          borderTop: isDark ? '1px solid rgba(255,255,255,0.06)' : '1px solid rgba(7,23,46,0.06)',
-        }}
+        className="flex justify-around py-3 px-5 bg-[var(--surface-card)]"
+        style={{ borderTop: '1px solid var(--border-default)' }}
       >
         <NavItem icon="🏠" label="Home" active isDark={isDark} />
         <NavItem icon="📊" label="Dashboard" isDark={isDark} />
@@ -400,9 +392,7 @@ export function MobileLandingPage({ onPointAndScan }: LandingPageProps) {
       </nav>
 
       {/* Footer */}
-      <footer
-        className={`py-6 text-center ${isDark ? 'bg-[#061324]' : 'bg-[var(--surface-card)]'}`}
-      >
+      <footer className="py-6 text-center bg-[var(--surface-card)]">
         <p className={`text-sm ${isDark ? 'text-gray-400' : 'text-[var(--text-secondary)]'}`}>
           © 2026 DealGapIQ. All rights reserved.
         </p>

--- a/frontend/src/components/ui/VideoModal.tsx
+++ b/frontend/src/components/ui/VideoModal.tsx
@@ -96,7 +96,7 @@ export function VideoModal({ open, onClose, src, title }: VideoModalProps) {
           autoPlay
           playsInline
           className="w-full block"
-          style={{ aspectRatio: '16/9', background: '#000' }}
+          style={{ aspectRatio: '16/9', background: 'var(--surface-media-letterbox)' }}
         />
       </div>
     </div>


### PR DESCRIPTION
## Summary

Phase 2 sub-PR 2 of the audit-remediation roadmap. Eliminates the **live, user-affecting** hardcoded-hex violations of the workspace theme-surface contract (`.cursor/rules/theme-surface-contract.mdc`).

**Targets PR #56 (P2.1)**, not main, because this branch is rebased on top of the React 19 type bump from P2.1. Merge P2.1 first; this PR's base will auto-update to `main`.

Net diff: **+11 / -10** across 3 files.

## What's fixed

| File | Before | After |
|---|---|---|
| `MobileLandingPage.tsx` outer shell | `bg-[#07172e] text-[#e1e8ed]` (dark only) | `bg-[var(--surface-base)] text-[var(--text-body)]` |
| `MobileLandingPage.tsx` bottom nav | `bg-[#061324]` (dark only) | `bg-[var(--surface-card)]` |
| `MobileLandingPage.tsx` footer | `bg-[#061324]` (dark only) | `bg-[var(--surface-card)]` |
| `MobileLandingPage.tsx` nav border | `1px solid rgba(...)` (theme-aware via JS) | `1px solid var(--border-default)` (theme-aware via CSS) |
| `globals.css` | — | New `--surface-media-letterbox: #000000` token (constant in both themes) |
| `VideoModal.tsx` `<video>` letterbox | `background: '#000'` (literal hex) | `background: 'var(--surface-media-letterbox)'` |

The `MobileLandingPage` hero gradient (`linear-gradient(180deg, #0a1628 ...)`) is **untouched** — gradients-for-visual-effect are an explicitly allowed exception per the workspace surface-contract rule.

## Why a dedicated `--surface-media-letterbox` token

The `<video>` letterbox color is **not** a "container surface" and shouldn't follow the theme. Industry-standard UX (YouTube, Vimeo, native players) letterboxes black regardless of light/dark mode. The new token captures that intent without weakening the surface-token contract:

- It's defined once in `:root` (no light-theme override)
- The name communicates the use case (any future media-letterbox needs reuse it)
- The theme check script's allowlist already excludes `globals.css`, so the literal `#000000` lives only there

## What's intentionally not fixed here

`DealGapIQHomepageV2.tsx` still has **58 violations** (`bg-black`, `background:'#000'`, etc.). All of them disappear when V2 is deleted in **P2.6 — landing consolidation**. Fixing them in place would be throwaway work since the entire file goes away.

The strict theme check is therefore still red on V2. This was already true on `main` baseline pre-Phase 1; CI's behavior on `theme:check:strict` failures is unchanged by this PR.

## Verification

| Check | Result |
|---|---|
| `npm run lint` | ✅ 0 errors |
| `npx tsc --noEmit` | ✅ 0 errors (depends on P2.1's React 19 type fixes) |
| `npm run test:run` | ✅ 136 / 136 passing |
| `bash scripts/check-theme-surfaces.sh --strict` | 58 violations in 1 file (V2; **down from 59** — VideoModal cleared) |

## Test plan

- [ ] Open `/?mobile=force` (or load on a phone) — `MobileLandingPage` renders correctly in both **light** and **dark** themes (no broken contrast, no flash of wrong background)
- [ ] Open any page that triggers `VideoModal` (e.g. landing page video) — letterbox stays solid black around aspect-ratio padding (light or dark theme)
- [ ] Toggle theme while `MobileLandingPage` is mounted — surfaces transition smoothly via CSS variables (no JS-driven flash)

## Stack order

```
main
 ↓
P2.1 (PR #56) — dead code + React 19 types
 ↓
P2.2 (this PR) — theme contract fixes
 ↓
... P2.3 → P2.12 to follow
```

Made with [Cursor](https://cursor.com)