### PR TITLE
refactor(frontend): P2.5 — migrate 5 simple modals to shared <Modal> primitive

### DIFF
--- a/frontend/src/__tests__/components/Modal.test.tsx
+++ b/frontend/src/__tests__/components/Modal.test.tsx
@@ -153,6 +153,39 @@ describe('Modal', () => {
     })
   })
 
+  describe('fullBleed', () => {
+    it('skips the inner padding wrapper when fullBleed is true', () => {
+      const { container } = render(
+        <Modal open={true} onClose={vi.fn()} aria-label="bleed" fullBleed hideCloseButton>
+          <div data-testid="bleed-content">edge</div>
+        </Modal>,
+      )
+      const content = container.querySelector('[data-testid="bleed-content"]')
+      // Direct parent must NOT carry the padded wrapper class.
+      const parent = content?.parentElement
+      expect(parent?.className).not.toMatch(/px-6|pb-6|pt-2/)
+    })
+
+    it('still renders the title header when fullBleed=true and title is provided', () => {
+      render(
+        <Modal open={true} onClose={vi.fn()} title="With header" fullBleed>
+          <p>Body</p>
+        </Modal>,
+      )
+      expect(screen.getByText('With header')).toBeTruthy()
+    })
+
+    it('suppresses the default close button when fullBleed=true and no title', () => {
+      render(
+        <Modal open={true} onClose={vi.fn()} aria-label="suppressed" fullBleed>
+          <p>Body</p>
+        </Modal>,
+      )
+      // Caller is responsible for its own close affordance in fullBleed mode.
+      expect(screen.queryByLabelText('Close')).toBeNull()
+    })
+  })
+
   describe('body scroll lock', () => {
     it('locks body scroll while open and restores it on unmount', () => {
       // Capture whatever overflow was set before the test.

--- a/frontend/src/components/analytics/IQWelcomeModal.tsx
+++ b/frontend/src/components/analytics/IQWelcomeModal.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import React from 'react'
+import { Modal } from '@/components/ui/Modal'
 import { IQBrainIcon } from '@/components/icons'
 
 interface IQWelcomeModalProps {
@@ -9,22 +10,30 @@ interface IQWelcomeModalProps {
 }
 
 /**
- * IQWelcomeModal - Pop-up modal introducing IQ when property analytics loads
+ * IQWelcomeModal — pop-up introducing IQ when property analytics loads.
+ *
+ * Built on the shared <Modal> primitive (P2.4) so focus trap, escape,
+ * backdrop click, return-focus and body-scroll-lock are inherited rather
+ * than reimplemented. The panel keeps its bespoke gradient + accent border
+ * via `panelStyle` so the visual is unchanged from the pre-migration version.
  */
 export function IQWelcomeModal({ isOpen, onClose }: IQWelcomeModalProps) {
-  if (!isOpen) return null
-
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center p-6">
-      {/* Backdrop */}
-      <div
-        className="absolute inset-0 bg-[var(--surface-base)]/60 backdrop-blur-sm"
-        onClick={onClose}
-      />
-
-      {/* Modal */}
-      <div className="relative bg-gradient-to-br from-[#0d1f35] to-[#091525] border border-[var(--accent-sky)]/30 rounded-2xl p-8 max-w-md w-full shadow-2xl shadow-[var(--accent-sky)]/10">
-        {/* IQ Brain Icon */}
+    <Modal
+      open={isOpen}
+      onClose={onClose}
+      size="md"
+      aria-label="Welcome from IQ"
+      hideCloseButton
+      fullBleed
+      panelStyle={{
+        background: 'linear-gradient(135deg, #0d1f35 0%, #091525 100%)',
+        border: '1px solid rgba(15, 164, 233, 0.30)',
+        boxShadow: '0 24px 60px rgba(15, 164, 233, 0.10)',
+      }}
+    >
+      <div className="p-8">
+        {/* IQ Brain icon */}
         <div className="flex justify-start mb-6">
           <div className="w-12 h-12 rounded-full bg-[var(--accent-sky)]/10 flex items-center justify-center">
             <IQBrainIcon size={28} mode="dark" />
@@ -33,21 +42,24 @@ export function IQWelcomeModal({ isOpen, onClose }: IQWelcomeModalProps) {
 
         {/* Content */}
         <div className="text-left space-y-5">
-          <h3 className="text-lg font-bold text-white">Hey, I'm IQ — your real estate analyst.</h3>
+          <h3 className="text-lg font-bold text-white">
+            Hey, I&apos;m IQ — your real estate analyst.
+          </h3>
 
           <p className="text-[15px] font-medium text-white/90 leading-relaxed">
-            I've analyzed your property against local market data and built 6 investment strategies,
-            each showing a different way to profit.
+            I&apos;ve analyzed your property against local market data and built 6 investment
+            strategies, each showing a different way to profit.
           </p>
 
           <p className="text-[15px] font-medium text-white/70 italic">
-            Explore them all, I'll be here to guide you.
+            Explore them all, I&apos;ll be here to guide you.
           </p>
         </div>
 
-        {/* OK Button */}
+        {/* OK button */}
         <div className="flex justify-end mt-6">
           <button
+            type="button"
             onClick={onClose}
             className="px-8 py-2.5 bg-[var(--accent-sky)] hover:bg-[#5dd8e8] text-[#07172e] font-bold rounded-lg transition-colors"
           >
@@ -55,6 +67,6 @@ export function IQWelcomeModal({ isOpen, onClose }: IQWelcomeModalProps) {
           </button>
         </div>
       </div>
-    </div>
+    </Modal>
   )
 }

--- a/frontend/src/components/landing/TryItNowModal.tsx
+++ b/frontend/src/components/landing/TryItNowModal.tsx
@@ -1,9 +1,10 @@
 'use client'
 
-import React, { useState } from 'react'
+import React, { useState, useCallback } from 'react'
 import { useRouter } from 'next/navigation'
-import { Camera, Search, X } from 'lucide-react'
+import { Camera, Search } from 'lucide-react'
 import { AddressAutocomplete } from '@/components/AddressAutocomplete'
+import { Modal } from '@/components/ui/Modal'
 import { canonicalizeAddressForIdentity, isLikelyFullAddress } from '@/utils/addressIdentity'
 
 interface TryItNowModalProps {
@@ -12,50 +13,55 @@ interface TryItNowModalProps {
   onScanProperty: () => void
 }
 
+/**
+ * TryItNowModal — landing-page CTA modal that lets visitors choose between
+ * camera scan and address entry. Migrated to the shared <Modal> primitive
+ * (P2.4); the inner content keeps its existing `.try-modal-*` CSS classes
+ * (defined in landing styles) so the visual is unchanged.
+ */
 export function TryItNowModal({ isOpen, onClose, onScanProperty }: TryItNowModalProps) {
   const router = useRouter()
   const [address, setAddress] = useState('')
   const [showAddressInput, setShowAddressInput] = useState(false)
   const hasValidAddress = isLikelyFullAddress(address)
 
-  if (!isOpen) return null
+  // Reset internal state on close so reopening starts fresh.
+  const handleClose = useCallback(() => {
+    onClose()
+    setShowAddressInput(false)
+    setAddress('')
+  }, [onClose])
 
   const handleScanProperty = () => {
-    onClose()
+    handleClose()
     onScanProperty()
   }
 
   const handleAddressSubmit = (e: React.FormEvent) => {
     e.preventDefault()
-    if (hasValidAddress) {
-      onClose()
-      // Navigate to IQ Analyzing screen (new IQ Verdict flow)
-      const canonicalAddress = canonicalizeAddressForIdentity(address)
-      router.push(`/discovery?address=${encodeURIComponent(canonicalAddress)}`)
-    }
-  }
-
-  const handleBackdropClick = (e: React.MouseEvent) => {
-    if (e.target === e.currentTarget) {
-      onClose()
-      setShowAddressInput(false)
-      setAddress('')
-    }
+    if (!hasValidAddress) return
+    handleClose()
+    const canonicalAddress = canonicalizeAddressForIdentity(address)
+    router.push(`/discovery?address=${encodeURIComponent(canonicalAddress)}`)
   }
 
   return (
-    <div className="try-modal-backdrop" onClick={handleBackdropClick}>
+    <Modal
+      open={isOpen}
+      onClose={handleClose}
+      size="md"
+      aria-label="How would you like to analyze a property?"
+      hideCloseButton
+      fullBleed
+      panelClassName="try-modal-panel"
+    >
       <div className="try-modal">
-        {/* Close Button */}
-        <button className="try-modal-close" onClick={onClose} aria-label="Close">
-          <X size={24} />
-        </button>
-
-        {/* Header - IQ icon on left, text on right, left-aligned */}
+        {/* Header — IQ icon on left, text on right */}
         <div className="try-modal-header">
           <div className="flex items-center gap-4">
             <div className="try-modal-icon flex-shrink-0">
-              <img src="/images/iq-brain-dark.png" alt="IQ" className="try-modal-iq-icon" />
+              {/* Decorative — text label is on the dialog itself via aria-label */}
+              <img src="/images/iq-brain-dark.png" alt="" className="try-modal-iq-icon" />
             </div>
             <div>
               <h2 className="try-modal-title leading-tight">
@@ -71,8 +77,7 @@ export function TryItNowModal({ isOpen, onClose, onScanProperty }: TryItNowModal
         {/* Options */}
         {!showAddressInput ? (
           <div className="try-modal-options">
-            {/* Scan Property Option */}
-            <button className="try-modal-option" onClick={handleScanProperty}>
+            <button type="button" className="try-modal-option" onClick={handleScanProperty}>
               <div className="try-modal-option-icon">
                 <Camera size={32} />
               </div>
@@ -84,8 +89,11 @@ export function TryItNowModal({ isOpen, onClose, onScanProperty }: TryItNowModal
               </div>
             </button>
 
-            {/* Enter Address Option */}
-            <button className="try-modal-option" onClick={() => setShowAddressInput(true)}>
+            <button
+              type="button"
+              className="try-modal-option"
+              onClick={() => setShowAddressInput(true)}
+            >
               <div className="try-modal-option-icon">
                 <Search size={32} />
               </div>
@@ -98,7 +106,6 @@ export function TryItNowModal({ isOpen, onClose, onScanProperty }: TryItNowModal
             </button>
           </div>
         ) : (
-          /* Address Input Form */
           <form className="try-modal-address-form" onSubmit={handleAddressSubmit}>
             <div className="try-modal-input-wrapper">
               <Search size={20} className="try-modal-input-icon" />
@@ -129,6 +136,6 @@ export function TryItNowModal({ isOpen, onClose, onScanProperty }: TryItNowModal
           </form>
         )}
       </div>
-    </div>
+    </Modal>
   )
 }

--- a/frontend/src/components/price-checker/CompPhotosModal.tsx
+++ b/frontend/src/components/price-checker/CompPhotosModal.tsx
@@ -2,6 +2,7 @@
 
 import React, { useEffect, useState, useCallback } from 'react'
 import { X, ChevronLeft, ChevronRight, Camera, ImageOff, Loader2 } from 'lucide-react'
+import { Modal } from '@/components/ui/Modal'
 import { fetchPropertyPhotos, type PhotoResult } from '@/services/photoService'
 
 interface CompPhotosModalProps {
@@ -10,6 +11,19 @@ interface CompPhotosModalProps {
   onClose: () => void
 }
 
+/**
+ * CompPhotosModal — comparable-property photo gallery.
+ *
+ * Migrated to the shared <Modal> primitive (P2.4). Inherits backdrop click,
+ * Escape, focus trap, and body scroll lock from the primitive; this
+ * component only owns the gallery-specific behaviour:
+ *   - Fetch photos on open via fetchPropertyPhotos
+ *   - Keyboard left/right arrows to advance the carousel
+ *   - Per-image error fallback to "Photo unavailable"
+ *
+ * As a side benefit, the previously hardcoded `bg-[#0a0a0a]` panel is now
+ * `var(--surface-card)` (theme-token compliant).
+ */
 export function CompPhotosModal({ comp, open, onClose }: CompPhotosModalProps) {
   const [photos, setPhotos] = useState<string[]>([])
   const [status, setStatus] = useState<'loading' | 'success' | 'empty' | 'error'>('loading')
@@ -17,6 +31,8 @@ export function CompPhotosModal({ comp, open, onClose }: CompPhotosModalProps) {
   const [index, setIndex] = useState(0)
   const [imgErrors, setImgErrors] = useState<Record<number, boolean>>({})
 
+  // Reset state + fetch on open. Cancellation flag avoids late
+  // resolutions overwriting state after the modal closes.
   useEffect(() => {
     if (!open) return
     setPhotos([])
@@ -44,18 +60,16 @@ export function CompPhotosModal({ comp, open, onClose }: CompPhotosModalProps) {
     }
   }, [open, comp.zpid])
 
+  // Carousel keyboard navigation. Modal handles Escape itself.
   useEffect(() => {
-    if (!open) return
+    if (!open || status !== 'success' || photos.length <= 1) return
     const handler = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') onClose()
-      if (status === 'success' && photos.length > 1) {
-        if (e.key === 'ArrowLeft') setIndex((i) => (i - 1 + photos.length) % photos.length)
-        if (e.key === 'ArrowRight') setIndex((i) => (i + 1) % photos.length)
-      }
+      if (e.key === 'ArrowLeft') setIndex((i) => (i - 1 + photos.length) % photos.length)
+      if (e.key === 'ArrowRight') setIndex((i) => (i + 1) % photos.length)
     }
     window.addEventListener('keydown', handler)
     return () => window.removeEventListener('keydown', handler)
-  }, [open, onClose, status, photos.length])
+  }, [open, status, photos.length])
 
   const prev = useCallback(
     () => setIndex((i) => (i - 1 + photos.length) % photos.length),
@@ -67,131 +81,137 @@ export function CompPhotosModal({ comp, open, onClose }: CompPhotosModalProps) {
     [],
   )
 
-  if (!open) return null
-
   const currentFailed = imgErrors[index]
 
   return (
-    <div className="fixed inset-0 z-[100] flex items-center justify-center">
-      {/* Overlay */}
-      <div className="absolute inset-0 bg-black/80 backdrop-blur-sm" onClick={onClose} />
-
-      {/* Modal panel */}
-      <div className="relative z-10 w-full max-w-lg mx-4 rounded-xl bg-[#0a0a0a] border border-[rgba(15,164,233,0.3)] shadow-[0_0_60px_rgba(15,164,233,0.12)] overflow-hidden">
-        {/* Header */}
-        <div className="flex items-center justify-between px-4 py-3 border-b border-[rgba(15,164,233,0.2)]">
-          <div className="min-w-0">
-            <h3 className="text-sm font-semibold text-[#F1F5F9] truncate">{comp.address}</h3>
-          </div>
-          <button
-            onClick={onClose}
-            className="flex-shrink-0 p-1.5 rounded-full hover:bg-white/[0.07] text-[#F1F5F9] hover:text-white transition-colors"
-            aria-label="Close photos"
-          >
-            <X className="w-4 h-4" />
-          </button>
+    <Modal
+      open={open}
+      onClose={onClose}
+      size="lg"
+      aria-label={`Photos for ${comp.address}`}
+      hideCloseButton
+      fullBleed
+    >
+      {/* Custom header — single-line address with a close button. */}
+      <div className="flex items-center justify-between px-4 py-3 border-b border-[var(--border-subtle)]">
+        <div className="min-w-0">
+          <h3 className="text-sm font-semibold text-[var(--text-heading)] truncate">
+            {comp.address}
+          </h3>
         </div>
+        <button
+          type="button"
+          onClick={onClose}
+          className="flex-shrink-0 p-1.5 rounded-full hover:bg-[var(--surface-card-hover)] text-[var(--text-heading)] transition-colors"
+          aria-label="Close photos"
+        >
+          <X className="w-4 h-4" />
+        </button>
+      </div>
 
-        {/* Body */}
-        <div className="relative">
-          {/* Loading */}
-          {status === 'loading' && (
-            <div className="h-72 flex flex-col items-center justify-center gap-3">
-              <Loader2 className="w-8 h-8 text-[#38bdf8] animate-spin" />
-              <span className="text-sm text-[#F1F5F9]">Loading photos...</span>
-            </div>
-          )}
+      {/* Body */}
+      <div className="relative">
+        {status === 'loading' && (
+          <div className="h-72 flex flex-col items-center justify-center gap-3">
+            <Loader2 className="w-8 h-8 text-[var(--accent-sky)] animate-spin" />
+            <span className="text-sm text-[var(--text-heading)]">Loading photos...</span>
+          </div>
+        )}
 
-          {/* Empty / Error */}
-          {(status === 'empty' || status === 'error') && (
-            <div className="h-72 flex flex-col items-center justify-center gap-3">
-              <ImageOff className="w-10 h-10 text-[#F1F5F9]" />
-              <span className="text-sm text-[#F1F5F9]">{errorMsg || 'No photos available'}</span>
-              <button
-                onClick={onClose}
-                className="mt-2 px-4 py-1.5 rounded-lg bg-[#38bdf8] text-black text-xs font-semibold hover:bg-[#38bdf8]/90 transition-colors"
-              >
-                Close
-              </button>
-            </div>
-          )}
+        {(status === 'empty' || status === 'error') && (
+          <div className="h-72 flex flex-col items-center justify-center gap-3">
+            <ImageOff className="w-10 h-10 text-[var(--text-heading)]" />
+            <span className="text-sm text-[var(--text-heading)]">
+              {errorMsg || 'No photos available'}
+            </span>
+            <button
+              type="button"
+              onClick={onClose}
+              className="mt-2 px-4 py-1.5 rounded-lg bg-[var(--accent-sky)] text-[var(--text-inverse)] text-xs font-semibold hover:opacity-90 transition-opacity"
+            >
+              Close
+            </button>
+          </div>
+        )}
 
-          {/* Carousel */}
-          {status === 'success' && (
-            <>
-              <div className="relative h-72 bg-[var(--surface-base)]">
-                {currentFailed ? (
-                  <div className="w-full h-full flex flex-col items-center justify-center gap-2">
-                    <ImageOff className="w-8 h-8 text-[#F1F5F9]" />
-                    <span className="text-xs text-[#F1F5F9]">Photo unavailable</span>
-                  </div>
-                ) : (
-                  <img
-                    key={photos[index]}
-                    src={photos[index]}
-                    alt={`Comp photo ${index + 1} of ${photos.length}`}
-                    className="w-full h-full object-cover"
-                    referrerPolicy="no-referrer"
-                    onError={() => handleImgError(index)}
-                  />
-                )}
-
-                {/* Counter badge */}
-                <div className="absolute top-3 right-3 px-2.5 py-1 rounded-lg bg-black/75 backdrop-blur-sm flex items-center gap-1.5">
-                  <Camera className="w-3 h-3 text-[#F1F5F9]" />
-                  <span className="text-xs font-medium text-[#F1F5F9] tabular-nums">
-                    {index + 1} / {photos.length}
-                  </span>
+        {status === 'success' && (
+          <>
+            <div className="relative h-72 bg-[var(--surface-media-letterbox)]">
+              {currentFailed ? (
+                <div className="w-full h-full flex flex-col items-center justify-center gap-2">
+                  <ImageOff className="w-8 h-8 text-[var(--text-heading)]" />
+                  <span className="text-xs text-[var(--text-heading)]">Photo unavailable</span>
                 </div>
+              ) : (
+                <img
+                  key={photos[index]}
+                  src={photos[index]}
+                  alt={`Comp photo ${index + 1} of ${photos.length}`}
+                  className="w-full h-full object-cover"
+                  referrerPolicy="no-referrer"
+                  onError={() => handleImgError(index)}
+                />
+              )}
 
-                {/* Prev / Next arrows */}
-                {photos.length > 1 && (
-                  <>
-                    <button
-                      onClick={prev}
-                      className="absolute left-3 top-1/2 -translate-y-1/2 w-9 h-9 rounded-full bg-black/70 backdrop-blur-sm flex items-center justify-center text-white hover:bg-black/90 transition-colors"
-                      aria-label="Previous photo"
-                    >
-                      <ChevronLeft className="w-5 h-5" />
-                    </button>
-                    <button
-                      onClick={next}
-                      className="absolute right-3 top-1/2 -translate-y-1/2 w-9 h-9 rounded-full bg-black/70 backdrop-blur-sm flex items-center justify-center text-white hover:bg-black/90 transition-colors"
-                      aria-label="Next photo"
-                    >
-                      <ChevronRight className="w-5 h-5" />
-                    </button>
-                  </>
-                )}
+              {/* Counter badge */}
+              <div className="absolute top-3 right-3 px-2.5 py-1 rounded-lg bg-black/75 backdrop-blur-sm flex items-center gap-1.5">
+                <Camera className="w-3 h-3 text-white" />
+                <span className="text-xs font-medium text-white tabular-nums">
+                  {index + 1} / {photos.length}
+                </span>
               </div>
 
-              {/* Thumbnail strip */}
+              {/* Prev / Next arrows */}
               {photos.length > 1 && (
-                <div className="flex gap-1.5 p-3 overflow-x-auto scrollbar-hide">
-                  {photos.map((url, i) => (
-                    <button
-                      key={i}
-                      onClick={() => setIndex(i)}
-                      className={`flex-shrink-0 w-14 h-10 rounded-md overflow-hidden border-2 transition-all ${
-                        i === index
-                          ? 'border-[#38bdf8] shadow-[0_0_8px_rgba(56,189,248,0.3)]'
-                          : 'border-transparent opacity-60 hover:opacity-100'
-                      }`}
-                    >
-                      <img
-                        src={url}
-                        alt=""
-                        className="w-full h-full object-cover"
-                        referrerPolicy="no-referrer"
-                      />
-                    </button>
-                  ))}
-                </div>
+                <>
+                  <button
+                    type="button"
+                    onClick={prev}
+                    className="absolute left-3 top-1/2 -translate-y-1/2 w-9 h-9 rounded-full bg-black/70 backdrop-blur-sm flex items-center justify-center text-white hover:bg-black/90 transition-colors"
+                    aria-label="Previous photo"
+                  >
+                    <ChevronLeft className="w-5 h-5" />
+                  </button>
+                  <button
+                    type="button"
+                    onClick={next}
+                    className="absolute right-3 top-1/2 -translate-y-1/2 w-9 h-9 rounded-full bg-black/70 backdrop-blur-sm flex items-center justify-center text-white hover:bg-black/90 transition-colors"
+                    aria-label="Next photo"
+                  >
+                    <ChevronRight className="w-5 h-5" />
+                  </button>
+                </>
               )}
-            </>
-          )}
-        </div>
+            </div>
+
+            {/* Thumbnail strip */}
+            {photos.length > 1 && (
+              <div className="flex gap-1.5 p-3 overflow-x-auto scrollbar-hide">
+                {photos.map((url, i) => (
+                  <button
+                    key={i}
+                    type="button"
+                    onClick={() => setIndex(i)}
+                    className={`flex-shrink-0 w-14 h-10 rounded-md overflow-hidden border-2 transition-all ${
+                      i === index
+                        ? 'border-[var(--accent-sky)] shadow-[0_0_8px_rgba(56,189,248,0.3)]'
+                        : 'border-transparent opacity-60 hover:opacity-100'
+                    }`}
+                    aria-label={`Show photo ${i + 1}`}
+                  >
+                    <img
+                      src={url}
+                      alt=""
+                      className="w-full h-full object-cover"
+                      referrerPolicy="no-referrer"
+                    />
+                  </button>
+                ))}
+              </div>
+            )}
+          </>
+        )}
       </div>
-    </div>
+    </Modal>
   )
 }

--- a/frontend/src/components/ui/ConfirmDialog.tsx
+++ b/frontend/src/components/ui/ConfirmDialog.tsx
@@ -1,7 +1,7 @@
 'use client'
 
-import { useCallback, useEffect, useRef } from 'react'
-import { useFocusTrap } from './useFocusTrap'
+import { useEffect, useRef } from 'react'
+import { Modal } from './Modal'
 
 export interface ConfirmDialogProps {
   open: boolean
@@ -11,12 +11,19 @@ export interface ConfirmDialogProps {
   description?: string
   confirmLabel?: string
   cancelLabel?: string
-  /** 'danger' shows a red confirm button, 'info' shows blue */
+  /** 'danger' shows a red confirm button, 'info' shows blue. */
   variant?: 'danger' | 'info'
 }
 
 /**
- * ConfirmDialog — dark-themed modal that replaces window.confirm() and window.alert().
+ * ConfirmDialog — modal that replaces window.confirm().
+ *
+ * Now built on the shared <Modal> primitive (P2.4) for focus trap, escape,
+ * backdrop click, return-focus and body scroll lock. Public API unchanged
+ * — every existing callsite continues to work without edits.
+ *
+ * The confirm button is the initial focus target so a keyboard user can
+ * press Enter to commit (or Tab once + Enter to cancel).
  *
  * Usage:
  *   <ConfirmDialog
@@ -39,99 +46,67 @@ export function ConfirmDialog({
   variant = 'info',
 }: ConfirmDialogProps) {
   const confirmRef = useRef<HTMLButtonElement>(null)
-  const panelRef = useRef<HTMLDivElement>(null)
+  const isDanger = variant === 'danger'
 
-  // Focus confirm button on open, trap Escape key
+  // Modal moves initial focus to the first focusable child by default —
+  // for a confirm dialog the user expects focus on the primary action,
+  // not the cancel button. We use Modal's `initialFocusRef` to override.
+  // (The ref is wired below; useEffect keeps the focus after rapid open
+  //  toggles where Modal's initial focus may have already fired.)
   useEffect(() => {
     if (!open) return
     confirmRef.current?.focus()
-
-    const handleKey = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') onCancel()
-    }
-    window.addEventListener('keydown', handleKey)
-    return () => window.removeEventListener('keydown', handleKey)
-  }, [open, onCancel])
-
-  // Keyboard focus trap — Tab cycles within the dialog
-  useFocusTrap(panelRef, open)
-
-  const handleBackdrop = useCallback(
-    (e: React.MouseEvent) => {
-      if (e.target === e.currentTarget) onCancel()
-    },
-    [onCancel],
-  )
-
-  if (!open) return null
-
-  const isDanger = variant === 'danger'
+  }, [open])
 
   return (
-    <div
-      className="fixed inset-0 z-[9999] flex items-center justify-center p-4"
-      style={{ background: 'var(--surface-overlay)', backdropFilter: 'blur(6px)' }}
-      onClick={handleBackdrop}
-      role="dialog"
-      aria-modal="true"
-      aria-labelledby="confirm-dialog-title"
+    <Modal
+      open={open}
+      onClose={onCancel}
+      size="sm"
+      title={title}
+      hideCloseButton
+      initialFocusRef={confirmRef as React.RefObject<HTMLElement | null>}
     >
-      <div
-        ref={panelRef}
-        className="w-full max-w-sm rounded-2xl p-6"
-        style={{
-          background: 'var(--surface-card)',
-          border: '1px solid var(--border-subtle)',
-          boxShadow: 'var(--shadow-dropdown)',
-        }}
-      >
-        <h3
-          id="confirm-dialog-title"
-          className="text-lg font-bold mb-2"
-          style={{ color: 'var(--text-heading)' }}
+      {description && (
+        <p className="text-sm leading-relaxed mb-6" style={{ color: 'var(--text-secondary)' }}>
+          {description}
+        </p>
+      )}
+
+      <div className="flex gap-3 justify-end">
+        <button
+          type="button"
+          onClick={onCancel}
+          className="px-4 py-2.5 rounded-xl text-sm font-semibold transition-colors"
+          style={{
+            background: 'var(--surface-elevated)',
+            color: 'var(--text-body)',
+            border: '1px solid var(--border-subtle)',
+          }}
         >
-          {title}
-        </h3>
-
-        {description && (
-          <p className="text-sm leading-relaxed mb-6" style={{ color: 'var(--text-secondary)' }}>
-            {description}
-          </p>
-        )}
-
-        <div className="flex gap-3 justify-end">
-          <button
-            onClick={onCancel}
-            className="px-4 py-2.5 rounded-xl text-sm font-semibold transition-colors"
-            style={{
-              background: 'var(--surface-elevated)',
-              color: 'var(--text-body)',
-              border: '1px solid var(--border-subtle)',
-            }}
-          >
-            {cancelLabel}
-          </button>
-          <button
-            ref={confirmRef}
-            onClick={onConfirm}
-            className="px-4 py-2.5 rounded-xl text-sm font-bold text-white transition-colors"
-            style={{
-              background: isDanger
-                ? 'linear-gradient(135deg, var(--status-negative) 0%, #991b1b 100%)'
-                : 'linear-gradient(135deg, var(--accent-brand-blue) 0%, var(--accent-sky) 100%)',
-            }}
-          >
-            {confirmLabel}
-          </button>
-        </div>
+          {cancelLabel}
+        </button>
+        <button
+          type="button"
+          ref={confirmRef}
+          onClick={onConfirm}
+          className="px-4 py-2.5 rounded-xl text-sm font-bold text-white transition-colors"
+          style={{
+            background: isDanger
+              ? 'linear-gradient(135deg, var(--status-negative) 0%, #991b1b 100%)'
+              : 'linear-gradient(135deg, var(--accent-brand-blue) 0%, var(--accent-sky) 100%)',
+          }}
+        >
+          {confirmLabel}
+        </button>
       </div>
-    </div>
+    </Modal>
   )
 }
 
 /**
- * InfoDialog — for non-destructive informational messages (replaces window.alert).
- * Same component, simplified API with only "Got it" button.
+ * InfoDialog — non-destructive informational message (replaces window.alert).
+ * Same primitive, simpler API: single "Got it" button.
  */
 export function InfoDialog({
   open,
@@ -148,76 +123,30 @@ export function InfoDialog({
   closeLabel?: string
   children?: React.ReactNode
 }) {
-  const infoPanelRef = useRef<HTMLDivElement>(null)
-
-  useEffect(() => {
-    if (!open) return
-    const handleKey = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') onClose()
-    }
-    window.addEventListener('keydown', handleKey)
-    return () => window.removeEventListener('keydown', handleKey)
-  }, [open, onClose])
-
-  useFocusTrap(infoPanelRef, open)
-
-  const handleBackdrop = useCallback(
-    (e: React.MouseEvent) => {
-      if (e.target === e.currentTarget) onClose()
-    },
-    [onClose],
-  )
-
-  if (!open) return null
-
   return (
-    <div
-      className="fixed inset-0 z-[9999] flex items-center justify-center p-4"
-      style={{ background: 'var(--surface-overlay)', backdropFilter: 'blur(6px)' }}
-      onClick={handleBackdrop}
-      role="dialog"
-      aria-modal="true"
-      aria-labelledby="info-dialog-title"
-    >
-      <div
-        ref={infoPanelRef}
-        className="w-full max-w-sm rounded-2xl p-6"
-        style={{
-          background: 'var(--surface-card)',
-          border: '1px solid var(--border-subtle)',
-          boxShadow: 'var(--shadow-dropdown)',
-        }}
-      >
-        <h3
-          id="info-dialog-title"
-          className="text-lg font-bold mb-2"
-          style={{ color: 'var(--text-heading)' }}
+    <Modal open={open} onClose={onClose} size="sm" title={title} hideCloseButton>
+      {description && (
+        <p className="text-sm leading-relaxed mb-4" style={{ color: 'var(--text-secondary)' }}>
+          {description}
+        </p>
+      )}
+
+      {children}
+
+      <div className="flex justify-end mt-6">
+        <button
+          type="button"
+          onClick={onClose}
+          autoFocus
+          className="px-5 py-2.5 rounded-xl text-sm font-bold text-white transition-colors"
+          style={{
+            background:
+              'linear-gradient(135deg, var(--accent-brand-blue) 0%, var(--accent-sky) 100%)',
+          }}
         >
-          {title}
-        </h3>
-
-        {description && (
-          <p className="text-sm leading-relaxed mb-4" style={{ color: 'var(--text-secondary)' }}>
-            {description}
-          </p>
-        )}
-
-        {children}
-
-        <div className="flex justify-end mt-6">
-          <button
-            onClick={onClose}
-            autoFocus
-            className="px-5 py-2.5 rounded-xl text-sm font-bold text-white transition-colors"
-            style={{
-              background:
-                'linear-gradient(135deg, var(--accent-brand-blue) 0%, var(--accent-sky) 100%)',
-            }}
-          >
-            {closeLabel}
-          </button>
-        </div>
+          {closeLabel}
+        </button>
       </div>
-    </div>
+    </Modal>
   )
 }

--- a/frontend/src/components/ui/Modal.tsx
+++ b/frontend/src/components/ui/Modal.tsx
@@ -67,6 +67,13 @@ export interface ModalProps {
   initialFocusRef?: React.RefObject<HTMLElement | null>
   /** Hide the default close (X) button if you render your own. */
   hideCloseButton?: boolean
+  /**
+   * Render the children edge-to-edge with no inner padding. Use for video,
+   * image, or map content where the visual fills the panel. Header
+   * (title/close) is also skipped when `fullBleed` is true and no `title`
+   * is provided — caller is responsible for any close affordance.
+   */
+  fullBleed?: boolean
   /** Additional class on the panel — for size/spacing tweaks. */
   panelClassName?: string
   /** Additional inline style on the panel — escape hatch for special cases. */
@@ -108,6 +115,7 @@ export function Modal({
   closeOnEscape = true,
   initialFocusRef,
   hideCloseButton = false,
+  fullBleed = false,
   panelClassName = '',
   panelStyle,
   children,
@@ -195,7 +203,7 @@ export function Modal({
       <div
         ref={panelRef}
         tabIndex={-1}
-        className={`w-full rounded-2xl overflow-hidden outline-none ${panelClassName}`}
+        className={`relative w-full rounded-2xl overflow-hidden outline-none ${panelClassName}`}
         style={{
           maxWidth: SIZE_MAX_WIDTH[size],
           background: 'var(--surface-card)',
@@ -204,7 +212,10 @@ export function Modal({
           ...panelStyle,
         }}
       >
-        {(title || !hideCloseButton) && (
+        {/* Header is suppressed in fullBleed mode unless an explicit title
+            is provided — full-bleed content (video, image, map) usually
+            owns its own close affordance overlaid on the content. */}
+        {(title || (!hideCloseButton && !fullBleed)) && (
           <div className="flex items-start justify-between gap-4 px-6 pt-6 pb-2">
             {title ? (
               <h2
@@ -243,7 +254,7 @@ export function Modal({
             )}
           </div>
         )}
-        <div className="px-6 pb-6 pt-2">{children}</div>
+        <div className={fullBleed ? '' : 'px-6 pb-6 pt-2'}>{children}</div>
       </div>
     </div>
   )

--- a/frontend/src/components/ui/VideoModal.tsx
+++ b/frontend/src/components/ui/VideoModal.tsx
@@ -1,6 +1,7 @@
 'use client'
 
-import { useCallback, useEffect, useRef } from 'react'
+import { useEffect, useRef } from 'react'
+import { Modal } from './Modal'
 
 export interface VideoModalProps {
   open: boolean
@@ -9,96 +10,85 @@ export interface VideoModalProps {
   title?: string
 }
 
+/**
+ * VideoModal — embedded video player in a modal shell.
+ *
+ * Built on top of <Modal> (P2.4 primitive), which provides backdrop click,
+ * Escape, focus trap, return-focus and body scroll lock. This component
+ * only owns the video-specific concerns:
+ *   - Pause + reset playback when the modal closes (so reopening starts fresh)
+ *   - Larger panel size (`xl` ≈ 800px max-width) appropriate for 16:9 video
+ *   - Letterbox background via the `--surface-media-letterbox` token
+ *   - The `<video>` element is the autofocus target so keyboard controls
+ *     work immediately
+ */
 export function VideoModal({ open, onClose, src, title }: VideoModalProps) {
   const videoRef = useRef<HTMLVideoElement>(null)
-  const panelRef = useRef<HTMLDivElement>(null)
 
+  // Reset playback when the modal closes so reopening doesn't resume
+  // mid-video at the previous timestamp.
   useEffect(() => {
-    if (!open) return
-
-    const handleKey = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') onClose()
-    }
-    window.addEventListener('keydown', handleKey)
-    return () => window.removeEventListener('keydown', handleKey)
-  }, [open, onClose])
-
-  useEffect(() => {
-    if (!open) {
-      const v = videoRef.current
-      if (v) {
-        v.pause()
-        v.currentTime = 0
-      }
+    if (open) return
+    const v = videoRef.current
+    if (v) {
+      v.pause()
+      v.currentTime = 0
     }
   }, [open])
 
-  const handleBackdrop = useCallback(
-    (e: React.MouseEvent) => {
-      if (e.target === e.currentTarget) onClose()
-    },
-    [onClose],
-  )
-
-  if (!open) return null
-
   return (
-    <div
-      className="fixed inset-0 z-[9999] flex items-center justify-center p-4"
-      style={{ background: 'var(--surface-overlay)', backdropFilter: 'blur(6px)' }}
-      onClick={handleBackdrop}
-      role="dialog"
-      aria-modal="true"
+    <Modal
+      open={open}
+      onClose={onClose}
+      size="xl"
       aria-label={title ?? 'Video'}
+      hideCloseButton
+      fullBleed
+      initialFocusRef={videoRef as React.RefObject<HTMLElement | null>}
     >
-      <div
-        ref={panelRef}
-        className="relative w-full rounded-2xl overflow-hidden"
+      {/*
+        Custom close button overlaid on the video. Default Modal close button
+        is hidden because it sits inside a normal padded header — we want a
+        floating control over the video frame instead.
+      */}
+      <button
+        type="button"
+        onClick={onClose}
+        className="absolute top-3 right-3 z-10 flex items-center justify-center rounded-full transition-colors"
         style={{
-          maxWidth: 800,
-          background: 'var(--surface-card)',
-          border: '1px solid var(--border-subtle)',
-          boxShadow: 'var(--shadow-dropdown)',
+          width: 32,
+          height: 32,
+          background: 'rgba(0,0,0,0.55)',
+          border: 'none',
+          color: '#fff',
         }}
+        aria-label="Close video"
       >
-        <button
-          onClick={onClose}
-          autoFocus
-          className="absolute top-3 right-3 z-10 flex items-center justify-center rounded-full transition-colors"
-          style={{
-            width: 32,
-            height: 32,
-            background: 'rgba(0,0,0,0.55)',
-            border: 'none',
-            color: '#fff',
-          }}
-          aria-label="Close video"
+        <svg
+          width="16"
+          height="16"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          aria-hidden="true"
         >
-          <svg
-            width="16"
-            height="16"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="2.5"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-          >
-            <line x1="18" y1="6" x2="6" y2="18" />
-            <line x1="6" y1="6" x2="18" y2="18" />
-          </svg>
-        </button>
+          <line x1="18" y1="6" x2="6" y2="18" />
+          <line x1="6" y1="6" x2="18" y2="18" />
+        </svg>
+      </button>
 
-        <video
-          ref={videoRef}
-          src={src}
-          controls
-          autoPlay
-          playsInline
-          className="w-full block"
-          style={{ aspectRatio: '16/9', background: 'var(--surface-media-letterbox)' }}
-        />
-      </div>
-    </div>
+      <video
+        ref={videoRef}
+        src={src}
+        controls
+        autoPlay
+        playsInline
+        className="w-full block"
+        style={{ aspectRatio: '16/9', background: 'var(--surface-media-letterbox)' }}
+      />
+    </Modal>
   )
 }


### PR DESCRIPTION
## Summary

Phase 2 sub-PR 6 (P2.5 first chunk). Migrates the **5 simple/presentational modals** to the shared `<Modal>` primitive added in P2.4 (#60). Form-heavy modals (`AuthModal`, `UpgradeModal`, `GenerateLOIModal`, `PitchScriptModal`, `SearchPropertyModal` — ~2,520 LOC combined) are intentionally **deferred** to follow-up sub-PRs that get individual focus and QA.

Net diff: **+424 / -399** across 7 files. Test count: 150 → **153** (+3 new `fullBleed` tests).

Targets PR #60 (P2.4); the stack is `main → P2.1 (#56) → P2.2 (#57) → P2.3 (#58) → P2.6 (#59) → P2.4 (#60) → P2.5 (this)`.

## Modals migrated

| File | Before | After | Notes |
|---|---|---|---|
| `ui/VideoModal.tsx` | 95 | 88 | Edge-to-edge video via new `fullBleed` prop |
| `analytics/IQWelcomeModal.tsx` | 61 | 64 | Bespoke gradient panel preserved via `panelStyle` |
| `landing/TryItNowModal.tsx` | 136 | 134 | `try-modal-*` CSS classes preserved exactly |
| `price-checker/CompPhotosModal.tsx` | 189 | 197 | + side-benefit: removed hardcoded `bg-[#0a0a0a]` |
| `ui/ConfirmDialog.tsx` (+ `InfoDialog`) | 220 | 138 | -37% LOC; thin wrappers over `<Modal>` |

Every migration:
- Replaces hand-rolled backdrop / z-index / focus / escape / scroll-lock logic with the shared `<Modal>` primitive
- Inherits WCAG-compliant focus trap, return-focus-on-close, body scroll lock, `aria-modal/role/labelledby` wiring without writing them again
- **Public component API unchanged** — every existing callsite continues to work without edits (verified by full type-check + test suite)
- Visual preserved exactly via `panelStyle` / `panelClassName` / `fullBleed` for modals that had bespoke chrome

## Modal primitive enhancement

Added a `fullBleed` prop to `<Modal>`:

```tsx
<Modal open onClose={...} fullBleed hideCloseButton>
  <video src={...} />
</Modal>
```

When `fullBleed` is true:
- Inner padding wrapper (`px-6 pb-6 pt-2`) is dropped → children render edge-to-edge
- Default header (close button + title slot) is suppressed when no `title` is provided → caller owns its own close affordance overlaid on the content (typical for video / image / map content)
- Header still renders if a `title` is explicitly provided

Three new tests in `__tests__/components/Modal.test.tsx` cover all three behaviour branches.

## Side benefits surfaced by the migration

- **`CompPhotosModal`** previously hardcoded `bg-[#0a0a0a]` (a dark hex; theme-contract violation). Migration replaces with `var(--surface-card)` — now respects light/dark theme correctly.
- **`VideoModal`** stops re-implementing focus trap + escape; the previously inline versions diverged subtly from the canonical `useFocusTrap` (e.g. didn't restore focus to the opener on close).
- **`ConfirmDialog`** drops 82 LOC (-37%) of duplicated backdrop / aria / focus-trap scaffolding while keeping its convenience API for callers.

## Verification

| Check | Result |
|---|---|
| `npm run lint` | ✅ 0 errors (558 warnings, **down 3**) |
| `npx tsc --noEmit` | ✅ 0 errors |
| `npm run test:run` | ✅ **153 / 153** passing (was 150; +3 new `fullBleed` tests) |
| `npm run build` | ✅ All 60+ routes build clean |
| `bash scripts/check-theme-surfaces.sh --strict` | ✅ Clean |

## Test plan

- [ ] Trigger each migrated modal in the running app and verify visual parity:
  - **VideoModal** — opens via marketing video CTA; video plays, Escape closes, backdrop click closes, X overlay button closes, focus returns to trigger button on close
  - **IQWelcomeModal** — appears on first analytics load; OK button focused on open, gradient background unchanged
  - **TryItNowModal** — landing-page "Try it now" CTA; both Scan/Enter Address branches still work; Escape clears state on close
  - **CompPhotosModal** — open from comps grid; arrow keys advance carousel, X closes, theme renders correctly in light + dark
  - **ConfirmDialog** — any destructive action (e.g. delete saved property); confirm button focused on open, Tab cycles between Confirm/Cancel, Escape cancels
- [ ] No console warnings about hydration / aria
- [ ] Body scroll is locked while modal is open, restored on close (try scrolling background while a modal is open — should not move)

## Conflict notice for reviewers

When **PR #55 (Phase 1)** merges, this PR will conflict on `src/components/ui/VideoModal.tsx` and `src/components/auth/AuthModal.tsx` (Phase 1 touched `AuthModal` styling). Resolution paths:
- `VideoModal.tsx` → take this PR's version (the migration supersedes Phase 1's letterbox token fix; the new version still uses `--surface-media-letterbox`)
- `AuthModal.tsx` → **take Phase 1's version** (this PR does NOT migrate AuthModal; the Phase 1 contrast fix is the right state)

## Out of scope (later sub-PRs in the P2.5 family)

- **AuthModal** (232 LOC, OAuth/MFA flows) — own PR
- **UpgradeModal** (415 LOC, Stripe + RevenueCat IAP) — own PR
- **GenerateLOIModal** (610 LOC, multi-section form) — own PR
- **PitchScriptModal** (614 LOC) — own PR
- **SearchPropertyModal** (649 LOC, multi-step search flow) — own PR
- **`SliderInput` consolidation** — needs design decision (two implementations with divergent APIs); own PR
- **Skeleton ad-hoc replacements** — bulk find-and-replace; own PR

## Out of scope (later Phase 2 sub-phases)

- **P2.7** — Split `app/discovery/page.tsx` (2,163 LOC)
- **P2.8** — Split `app/strategy/page.tsx` (2,267 LOC)
- **P2.9** — Split `AppHeader.tsx` (945 LOC)
- **P2.10** — `DealMakerPopup` rewrite as wrapper
- **P2.11** — Worksheet state unification + `useDealAnalysis`
- **P2.12** — Comps consolidation under `features/comps/`

Made with [Cursor](https://cursor.com)