### PR TITLE
fix(backend): add psycopg2-binary so sync DBAPI fallback works in tests

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -23,9 +23,17 @@ python-dotenv==1.0.0
 # ===========================================
 sqlalchemy[asyncio]==2.0.25
 alembic==1.13.1
-# Using psycopg3 instead of asyncpg - better SSL/connection handling
-# binary = bundled libpq, pool = async connection pooling
+# Using psycopg3 (psycopg) for the async runtime path —
+# better SSL / connection handling than asyncpg.
+#   binary = bundled libpq, pool = async connection pooling
 psycopg[binary,pool]==3.1.18
+# psycopg2-binary covers SQLAlchemy 2.0.x sync DBAPI fallback paths
+# (e.g. async_engine_from_config in alembic env.py creates a sync
+# engine internally for migrations; on this SQLAlchemy version the
+# `psycopg` dialect does not fully cover the sync side, so it imports
+# psycopg2). Production runtime uses psycopg3 only; this is test/migration
+# infrastructure only.
+psycopg2-binary>=2.9,<3
 
 # ===========================================
 # NEW: Authentication & Security


### PR DESCRIPTION
## Summary

After PR #65 (Postgres test fixtures) merged, the \`test\` job exposed a new failure that was previously hidden behind the pytest INTERNALERROR + SQLite UUID errors:

\`\`\`
ModuleNotFoundError: No module named 'psycopg2'
\`\`\`

Affecting **30+ tests** — every test that touches the database engine fixture.

## Root cause

Stack trace (representative):

\`\`\`
tests/conftest.py:157          await asyncio.to_thread(command.upgrade, alembic_cfg, "head")
alembic/env.py:109             run_migrations_online()
alembic/env.py:95              run_async_migrations()
                                → async_engine_from_config(...)
sqlalchemy/engine/create.py:601  dbapi = dbapi_meth(**dbapi_args)
sqlalchemy/dialects/postgresql/psycopg2.py:690
                                import psycopg2   ← fails here
\`\`\`

Despite the URL being \`postgresql+psycopg://...\` (psycopg3), **SQLAlchemy 2.0.25's \`psycopg\` dialect doesn't fully cover the SYNC DBAPI path** that \`async_engine_from_config\` uses internally during the alembic migration phase. It falls back to importing \`psycopg2\`. With psycopg2 not installed, every fixture that touches the test DB engine errors out.

## Fix

```diff
+psycopg2-binary>=2.9,<3
```

Adding \`psycopg2-binary\` lets SQLAlchemy use it for the sync fallback while keeping \`psycopg[binary,pool]==3.1.18\` (psycopg3) as the **async** runtime driver. **Production runtime is unaffected** — only alembic migration setup + sync test paths use psycopg2.

## Verification

Reproduced against CI run **25873346958** (job: test). Local verification not feasible without Postgres + Docker; CI is authoritative.

## What this does NOT fix

Two other backend test failures remain — both **pre-existing** issues that the prior INTERNALERROR + UUID errors were masking:

- **\`tests/test_billing.py\`** — references \`SubscriptionTier.STARTER\` which no longer exists (current enum is \`FREE\`/\`PRO\`). Billing tests are stale.
- **\`tests/test_api_integration.py\`** — calls \`calculate_flip()\` / \`calculate_wholesale()\` with stale signatures (calculator API has more required positional args than the tests provide).

These need the team to update the tests to match current code, beyond mechanical fixes I can make confidently. After this PR lands, those will be the last two test areas red on \`main\`.

## Stack

Targets \`main\`. Independent of any other open PR. After this lands plus the V2/V3 deletion (which the existing P2.6 / PR #59 covers), \`main\`'s frontend CI goes fully green; \`test\` job will be down to the two remaining stale-test issues above.

Made with [Cursor](https://cursor.com)