### PR TITLE
Revert "fix(backend): add psycopg2-binary" — made async-driver mismatch worse

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -23,17 +23,9 @@ python-dotenv==1.0.0
 # ===========================================
 sqlalchemy[asyncio]==2.0.25
 alembic==1.13.1
-# Using psycopg3 (psycopg) for the async runtime path —
-# better SSL / connection handling than asyncpg.
-#   binary = bundled libpq, pool = async connection pooling
+# Using psycopg3 instead of asyncpg - better SSL/connection handling
+# binary = bundled libpq, pool = async connection pooling
 psycopg[binary,pool]==3.1.18
-# psycopg2-binary covers SQLAlchemy 2.0.x sync DBAPI fallback paths
-# (e.g. async_engine_from_config in alembic env.py creates a sync
-# engine internally for migrations; on this SQLAlchemy version the
-# `psycopg` dialect does not fully cover the sync side, so it imports
-# psycopg2). Production runtime uses psycopg3 only; this is test/migration
-# infrastructure only.
-psycopg2-binary>=2.9,<3
 
 # ===========================================
 # NEW: Authentication & Security


### PR DESCRIPTION
## Summary

**Reverts PR #67.** That PR added \`psycopg2-binary\` to fix \`ModuleNotFoundError: No module named 'psycopg2'\` in the test job. The fix changed the failure mode but didn't actually solve it — and arguably made it harder to diagnose:

**Before #67:**
\`\`\`
ModuleNotFoundError: No module named 'psycopg2'
  at sqlalchemy/dialects/postgresql/psycopg2.py:690 → import psycopg2
\`\`\`

**After #67:**
\`\`\`
sqlalchemy.exc.InvalidRequestError: The asyncio extension requires
  an async driver to be used. The loaded 'psycopg2' is not async.
\`\`\`

## Real root cause

Both errors come from the same upstream bug: somewhere during \`alembic command.upgrade\` → \`async_engine_from_config\` → SQLAlchemy dialect dispatch, the **psycopg2 dialect is being selected** despite the URL being \`postgresql+psycopg://...\` (psycopg3). With psycopg2 absent, the import errors. With psycopg2 present, SQLAlchemy loads it then refuses because it isn't async.

The actual fix needs deeper investigation — likely one of:
- Bump SQLAlchemy from \`2.0.25\` to a later 2.0.x where psycopg3 sync/async dispatch is more robust
- Refactor \`backend/tests/conftest.py\` to not call \`alembic command.upgrade\` at all (use \`Base.metadata.create_all(engine)\` directly for tests)
- Track down where in the alembic chain a sync \`create_engine\` is called with a URL that resolves to psycopg2

None of these are 5-minute fixes. Reverting so \`main\` doesn't carry a misleading dep that doesn't actually fix anything.

## Impact

- \`test\` job remains red on main (was red before #67 also; this just changes the error message back to the more truthful one)
- \`lint\`, \`frontend-test\`, and Vercel jobs are unaffected — they were green and stay green
- The frontend P2 stack is **completely unaffected** — backend test issues are orthogonal

## Followup needed (separate from this PR)

The backend test infrastructure has multiple distinct issues now visible:
1. **psycopg2/psycopg3 dialect dispatch** in alembic test fixtures (the issue this PR concerns)
2. **\`SubscriptionTier.STARTER\`** — billing tests reference a removed enum value
3. **\`calculate_flip()\` / \`calculate_wholesale()\` signature drift** — calculator tests are stale

These all need owner investigation. They're beyond mechanical CI-unblock fixes.

Made with [Cursor](https://cursor.com)